### PR TITLE
fix(backend): add terramedic.org to ALLOWED_HOSTS on Lambda

### DIFF
--- a/backend/terramedic/core/settings.py
+++ b/backend/terramedic/core/settings.py
@@ -56,6 +56,7 @@ if IS_LAMBDA:
         or os.getenv("AWS_DEFAULT_REGION", "us-east-1")
     )
     ALLOWED_HOSTS.append(f".execute-api.{_aws_region}.amazonaws.com")
+    ALLOWED_HOSTS.append(".terramedic.org")
 
 
 # Application definition


### PR DESCRIPTION
## Summary
- Add `.terramedic.org` to `ALLOWED_HOSTS` when running on Lambda
- Custom domains (`api.terramedic.org`, `test-api.terramedic.org`) were returning 400 Bad Request

## Test plan
- [x] Confirmed 400 response from `test-api.terramedic.org` before fix
- [ ] Verify 200 response after deploy