### PR TITLE
fix(ci): remove unsupported cooldown fields from github-actions block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,5 +62,4 @@ updates:
       prefix: "chore(ci)"
     cooldown:
       default-days: 7
-      semver-major-days: 14
       include: ["*"]


### PR DESCRIPTION
## Summary

Follow-up to #180. The Dependabot config validation check
fails on PR #181 with:

> The property \`#/updates/1/cooldown/semver-major-days\` is
> not supported for the package ecosystem \`github-actions\`.

The granular \`semver-major-days\` / \`-minor-days\` / \`-patch-days\`
fields are **npm-only**. The \`github-actions\` ecosystem only
supports \`default-days\`.

## Change

Removes \`semver-major-days: 14\` from the \`github-actions\`
update block, leaving \`default-days: 7\`. The npm block is
unchanged.

## Test plan

- [ ] Dependabot validation check passes on this PR
- [ ] #181 rebases/merges cleanly and its check passes too