### PR TITLE
fix(ci): install Poetry after setup-python to use correct Python version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,15 +54,14 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
 
-      - name: Install Poetry
-        run: |
-          python3 -m pip install --user "poetry==2.1.3"
-
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
-          cache: "poetry"
+
+      - name: Install Poetry
+        run: |
+          python3 -m pip install --user "poetry==2.1.3"
 
       - name: Install dependencies
         working-directory: ./backend

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,14 +88,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Poetry
-        run: pip install poetry
-
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
-          cache: "poetry"
+
+      - name: Install Poetry
+        run: pip install poetry
 
       - name: Install dependencies
         working-directory: backend
@@ -129,14 +128,13 @@ jobs:
           mkdir -p ~/apt-cache
           cp /var/cache/apt/archives/*.deb ~/apt-cache/ 2>/dev/null || true
 
-      - name: Install Poetry
-        run: pip install poetry
-
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
-          cache: "poetry"
+
+      - name: Install Poetry
+        run: pip install poetry
 
       - name: Install dependencies
         working-directory: backend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,14 +35,13 @@ jobs:
           mkdir -p ~/apt-cache
           cp /var/cache/apt/archives/*.deb ~/apt-cache/ 2>/dev/null || true
 
-      - name: Install Poetry
-        run: pip install poetry
-
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
-          cache: "poetry"
+
+      - name: Install Poetry
+        run: pip install poetry
 
       - name: Install dependencies
         working-directory: backend


### PR DESCRIPTION
## Summary
- Reorders CI workflow steps so `setup-python` (Python 3.14) runs before `pip install poetry`, ensuring Poetry uses 3.14 instead of system Python 3.12
- Removes `cache: "poetry"` which required Poetry pre-installed
- Fixes deploy-backend failure on PR #181

## Test plan
- [ ] deploy-backend job passes
- [ ] Python Tests, Ruff, mypy jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)