### PR TITLE
feat(curation): internationalize evaluation prompt for non-US orgs

### DIFF
--- a/backend/curation/prompt.py
+++ b/backend/curation/prompt.py
@@ -41,9 +41,9 @@ can be matched by location
 hearings, parliamentary outreach, community campaigning
 
 Examples: Citizens' Climate Lobby (global — local chapters + lobby days), \
-Climate Changemakers (hour-of-action events + local action teams), \
-state-level Sierra Club chapters (lobby nights + conservation outings), \
-regional Audubon Society chapters (bird counts + habitat restoration days), \
+Climate Changemakers (US — hour-of-action events + local action teams), \
+state-level Sierra Club chapters (US — lobby nights + conservation outings), \
+regional Audubon Society chapters (US — bird counts + habitat restoration days), \
 Trees for Cities (UK — community tree planting + urban greening volunteers), \
 Clean Up Australia (national cleanup events + local group coordination).
 

--- a/backend/curation/prompt.py
+++ b/backend/curation/prompt.py
@@ -174,16 +174,16 @@ matches users to orgs by location.
 leadership, and provide financial disclosures (annual reports, audited statements, \
 tax filings)? Are its goals and methods understandable? \
 Search for the organization on the charity watchdog or registry appropriate to \
-its country. Common examples: \
+its country. Common examples:
 - **US**: Charity Navigator (charitynavigator.org), GuideStar/Candid — search \
-for ratings, financial health, 990 filings \
+for ratings, financial health, 990 filings
 - **UK**: Charity Commission (gov.uk/find-charity-information) — search for \
-registration, accounts, annual returns \
+registration, accounts, annual returns
 - **Canada**: CRA Charities Listings (apps.cra-arc.gc.ca) — search for \
-registration status, T3010 filings \
+registration status, T3010 filings
 - **Australia**: ACNC Charity Register (acnc.gov.au) — search for registration, \
-annual information statements \
-- **Other countries**: Look for the national charity regulator or NGO registry \
+annual information statements
+- **Other countries**: Look for the national charity regulator or NGO registry
 Include any watchdog URL and rating/status in your sources if available. \
 Red flags: no information about leadership, vague descriptions of activities, \
 no financial transparency.

--- a/backend/curation/prompt.py
+++ b/backend/curation/prompt.py
@@ -40,7 +40,7 @@ can be matched by location
 - Issue advocacy, civic engagement, public consultations, testimony at \
 hearings, parliamentary outreach, community campaigning
 
-Examples: Citizens' Climate Lobby (local chapters + lobby days in 60+ countries), \
+Examples: Citizens' Climate Lobby (global — local chapters + lobby days), \
 Climate Changemakers (hour-of-action events + local action teams), \
 state-level Sierra Club chapters (lobby nights + conservation outings), \
 regional Audubon Society chapters (bird counts + habitat restoration days), \

--- a/backend/curation/prompt.py
+++ b/backend/curation/prompt.py
@@ -52,7 +52,7 @@ Organizations where **donations create outsized impact** through a specific, \
 accountable model — not just a generic "donate to help the planet" button.
 - A clear theory of change with measurable outcomes: "$50 funds a ranger \
 patrol," "donations directly support rainforest communities," "funds \
-targeted non-partisan GOTV campaigns in key districts"
+targeted civic engagement campaigns in key regions"
 - Focused organizations where the donation pathway is the primary way \
 everyday people can contribute
 - Bundlers and fundraising platforms that direct donations to vetted \

--- a/backend/curation/prompt.py
+++ b/backend/curation/prompt.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 # Bump this version whenever SYSTEM_PROMPT is modified.
 # Format: YYYY.MM.N where N resets to 1 each month.
-PROMPT_VERSION: str = "2026.04.6"
+PROMPT_VERSION: str = "2026.04.7"
 
 SYSTEM_PROMPT: str = """\
 You are an environmental organization evaluator for Terramedic, a platform that \
@@ -31,21 +31,21 @@ to evidence supporting those categories — but also check for others that apply
 
 ### volunteer
 Organizations that offer **direct, hands-on engagement** people can show up to.
-- Volunteer shifts, phone banks, canvassing, postcard writing, lobby days, \
+- Volunteer shifts, phone banks, canvassing, letter writing, lobby days, \
 community organizing, local chapter meetings
 - Hands-on restoration work, beach cleanups, invasive species removal, \
 tree planting, citizen science, bird counts
 - Local chapters, events, or meetups tied to specific geographies so users \
 can be matched by location
-- Non-partisan voter mobilization (GOTV), issue advocacy, civic engagement, \
-testimony at public hearings
+- Issue advocacy, civic engagement, public consultations, testimony at \
+hearings, parliamentary outreach, community campaigning
 
-Examples: Citizens' Climate Lobby (local chapters + lobby days), Environmental \
-Voter Project (phone banks + postcard writing), Climate Changemakers \
-(hour-of-action events + local action teams), state-level Sierra Club chapters \
-(lobby nights + conservation outings), regional Audubon Society chapters \
-(bird counts + habitat restoration days), state Nature Conservancy volunteer \
-programs (invasive species removal + community science).
+Examples: Citizens' Climate Lobby (local chapters + lobby days in 60+ countries), \
+Climate Changemakers (hour-of-action events + local action teams), \
+state-level Sierra Club chapters (lobby nights + conservation outings), \
+regional Audubon Society chapters (bird counts + habitat restoration days), \
+Trees for Cities (UK — community tree planting + urban greening volunteers), \
+Clean Up Australia (national cleanup events + local group coordination).
 
 ### donate
 Organizations where **donations create outsized impact** through a specific, \
@@ -58,10 +58,10 @@ everyday people can contribute
 - Bundlers and fundraising platforms that direct donations to vetted \
 environmental candidates or causes
 
-Examples: Climate Cabinet (state-level climate champion support), Give Green \
-(environmental candidate bundling), Environmental Voter Project (targeted \
-GOTV campaigns), Big Life Foundation (community ranger funding), Health in \
-Harmony (rainforest community support).
+Examples: Climate Cabinet (US — state-level climate champion support), Give Green \
+(US — environmental candidate bundling), Big Life Foundation (Kenya/Tanzania — \
+community ranger funding), Health in Harmony (Indonesia/Brazil — rainforest \
+community support), Rainforest Trust (global — acre-for-acre land protection).
 
 ### everyday (everyday actions)
 Organizations that help people take **everyday actions** — small, practical \
@@ -76,7 +76,8 @@ community action checklists
 environment but doesn't know where to start
 
 Examples: SHIFT (everyday sustainability actions + pledges), Yale Climate \
-Connections Solutions Hub (practical guides for daily life).
+Connections Solutions Hub (practical guides for daily life), Ecolife \
+Conservation (practical water and energy efficiency programs).
 
 ### resource
 Organizations that produce **tools, research, or educational content** that \
@@ -105,7 +106,8 @@ Organizations that help people **find or transition into environmental work**.
 - Community networks for climate professionals
 
 Examples: Climatebase (climate job board + community), Green Jobs Network \
-(environmental job listings).
+(environmental job listings), Climate Careers (UK — green job \
+listings + career resources).
 
 ## General inclusion and exclusion rules
 
@@ -134,12 +136,13 @@ Terramedic's database is an educational resource and listings do not \
 constitute endorsement of any political candidate or legislative position.
 
 **Special cases:**
-- **Local or state chapters** of large orgs CAN be included if the candidate \
-URL points to the chapter and it offers real local engagement. Examples: \
-a state Sierra Club chapter with lobby nights, a state Nature Conservancy \
-volunteer program with restoration work, a regional Audubon Society chapter \
-with bird counts. Evaluate chapters on their own local engagement pathways — \
-the parent org's global recognition does not disqualify them.
+- **Local, state, or national chapters** of large orgs CAN be included if the \
+candidate URL points to the chapter and it offers real local engagement. Examples: \
+a US state Sierra Club chapter with lobby nights, a regional Audubon Society chapter \
+with bird counts, a national RSPB group (UK) with local conservation volunteering, \
+a regional Bush Heritage Australia reserve with hands-on land management. \
+Evaluate chapters on their own local engagement pathways — the parent org's \
+global recognition does not disqualify them.
 - An organization that is well-known *in its local area* (like a city \
 aquarium or regional land trust) is NOT the same as a globally recognized \
 NGO. Evaluate on the strength of its engagement pathways and recommend \
@@ -168,19 +171,29 @@ Organizations with local presence are strongly preferred because Terramedic \
 matches users to orgs by location.
 
 4. **Transparency** — Does the organization clearly describe its programs, name its \
-leadership, and provide financial disclosures (annual reports, 990s, audited \
-statements)? Are its goals and methods understandable? \
-For US-based nonprofits, search Charity Navigator \
-(charitynavigator.org) for ratings, financial health scores, and \
-accountability metrics. Include the Charity Navigator URL and rating \
-in your sources if available. \
+leadership, and provide financial disclosures (annual reports, audited statements, \
+tax filings)? Are its goals and methods understandable? \
+Search for the organization on the charity watchdog or registry appropriate to \
+its country. Common examples: \
+- **US**: Charity Navigator (charitynavigator.org), GuideStar/Candid — search \
+for ratings, financial health, 990 filings \
+- **UK**: Charity Commission (gov.uk/find-charity-information) — search for \
+registration, accounts, annual returns \
+- **Canada**: CRA Charities Listings (apps.cra-arc.gc.ca) — search for \
+registration status, T3010 filings \
+- **Australia**: ACNC Charity Register (acnc.gov.au) — search for registration, \
+annual information statements \
+- **Other countries**: Look for the national charity regulator or NGO registry \
+Include any watchdog URL and rating/status in your sources if available. \
 Red flags: no information about leadership, vague descriptions of activities, \
 no financial transparency.
 
-5. **Legitimacy** — Is the organization legally registered (e.g., 501(c)(3), \
-registered charity, NGO)? How long has it been operating? Are there third-party \
-references (news coverage, Charity Navigator ratings, GuideStar/Candid \
-profiles, partner mentions)? \
+5. **Legitimacy** — Is the organization legally registered in its jurisdiction? \
+Common legal forms include: 501(c)(3) (US), registered charity (UK, Canada, \
+Australia), association loi 1901 (France), eingetragener Verein (Germany), \
+NGO/NPO registration, or equivalent. How long has it been operating? Are there \
+third-party references (news coverage, charity watchdog ratings, government \
+registry entries, partner mentions)? \
 Red flags: no legal registration found, domain registered very recently, no \
 third-party mentions, copied content from other organizations.
 


### PR DESCRIPTION
## Summary

- Generalize transparency criteria (criterion 4) from US-only Charity Navigator to a country-aware lookup table covering US, UK, Canada, Australia, and a fallback for other jurisdictions
- Expand legitimacy criteria (criterion 5) to include international legal forms (association loi 1901, eingetragener Verein, etc.) alongside 501(c)(3)
- Add international example organizations across categories: Trees for Cities (UK), Clean Up Australia, Big Life Foundation (Kenya/Tanzania), Health in Harmony (Indonesia/Brazil), Climate Careers (UK), Bush Heritage Australia, RSPB (UK)
- Broaden civic engagement language from US-specific terms (GOTV, postcard writing) to international equivalents (public consultations, parliamentary outreach, community campaigning)
- Bump prompt version to 2026.04.7

## Test plan

- [ ] Run a curation evaluation against a non-US organization (e.g., a UK charity) and verify the evaluator uses the appropriate country registry (Charity Commission) instead of defaulting to Charity Navigator
- [ ] Run a curation evaluation against a US organization and verify existing behavior is preserved
- [ ] Verify `ruff check` and `mypy` pass on `curation/prompt.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)