### PR TITLE
feat(worker): split into dispatcher + evaluator Lambdas via SQS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,41 +135,25 @@ jobs:
             poetry run zappa deploy ${{ env.DEPLOY_ENV }} --docker-image-uri "$IMAGE_URI"
           fi
 
-      - name: Deploy worker Lambda
+      - name: Deploy worker and evaluator Lambdas
         working-directory: ./backend
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          WORKER_STAGE="${{ env.DEPLOY_ENV }}-worker"
           IMAGE_URI="${ECR_REGISTRY}/terramedic-${{ env.DEPLOY_ENV }}:latest"
-          FUNCTION_NAME="terramedic-${WORKER_STAGE}"
+          for ROLE in worker evaluator; do
+            STAGE="${{ env.DEPLOY_ENV }}-${ROLE}"
+            FUNCTION_NAME="terramedic-${STAGE}"
 
-          if aws lambda get-function --function-name "$FUNCTION_NAME" 2>/dev/null; then
-            echo "Updating worker Lambda..."
-            aws lambda wait function-updated --function-name "$FUNCTION_NAME"
-            poetry run zappa update "$WORKER_STAGE" --docker-image-uri "$IMAGE_URI"
-          else
-            echo "Creating worker Lambda..."
-            poetry run zappa deploy "$WORKER_STAGE" --docker-image-uri "$IMAGE_URI"
-          fi
-
-      - name: Deploy evaluator Lambda
-        working-directory: ./backend
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: |
-          EVALUATOR_STAGE="${{ env.DEPLOY_ENV }}-evaluator"
-          IMAGE_URI="${ECR_REGISTRY}/terramedic-${{ env.DEPLOY_ENV }}:latest"
-          FUNCTION_NAME="terramedic-${EVALUATOR_STAGE}"
-
-          if aws lambda get-function --function-name "$FUNCTION_NAME" 2>/dev/null; then
-            echo "Updating evaluator Lambda..."
-            aws lambda wait function-updated --function-name "$FUNCTION_NAME"
-            poetry run zappa update "$EVALUATOR_STAGE" --docker-image-uri "$IMAGE_URI"
-          else
-            echo "Creating evaluator Lambda..."
-            poetry run zappa deploy "$EVALUATOR_STAGE" --docker-image-uri "$IMAGE_URI"
-          fi
+            if aws lambda get-function --function-name "$FUNCTION_NAME" 2>/dev/null; then
+              echo "Updating ${ROLE} Lambda..."
+              aws lambda wait function-updated --function-name "$FUNCTION_NAME"
+              poetry run zappa update "$STAGE" --docker-image-uri "$IMAGE_URI"
+            else
+              echo "Creating ${ROLE} Lambda..."
+              poetry run zappa deploy "$STAGE" --docker-image-uri "$IMAGE_URI"
+            fi
+          done
 
       - name: Run database migrations
         working-directory: ./backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,6 +84,8 @@ jobs:
           DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
           ACM_CERTIFICATE_ARN: ${{ vars.ACM_CERTIFICATE_ARN }}
           ANTHROPIC_SECRET_ARN: ${{ secrets.ANTHROPIC_SECRET_ARN }}
+          EVALUATION_REQUESTS_QUEUE_URL: ${{ vars.EVALUATION_REQUESTS_QUEUE_URL }}
+          EVALUATION_RESULTS_QUEUE_URL: ${{ vars.EVALUATION_RESULTS_QUEUE_URL }}
         run: |
           poetry run python scripts/configure_zappa.py
           poetry run zappa save-python-settings-file ${{ env.DEPLOY_ENV }}
@@ -149,6 +151,24 @@ jobs:
           else
             echo "Creating worker Lambda..."
             poetry run zappa deploy "$WORKER_STAGE" --docker-image-uri "$IMAGE_URI"
+          fi
+
+      - name: Deploy evaluator Lambda
+        working-directory: ./backend
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          EVALUATOR_STAGE="${{ env.DEPLOY_ENV }}-evaluator"
+          IMAGE_URI="${ECR_REGISTRY}/terramedic-${{ env.DEPLOY_ENV }}:latest"
+          FUNCTION_NAME="terramedic-${EVALUATOR_STAGE}"
+
+          if aws lambda get-function --function-name "$FUNCTION_NAME" 2>/dev/null; then
+            echo "Updating evaluator Lambda..."
+            aws lambda wait function-updated --function-name "$FUNCTION_NAME"
+            poetry run zappa update "$EVALUATOR_STAGE" --docker-image-uri "$IMAGE_URI"
+          else
+            echo "Creating evaluator Lambda..."
+            poetry run zappa deploy "$EVALUATOR_STAGE" --docker-image-uri "$IMAGE_URI"
           fi
 
       - name: Run database migrations

--- a/backend/scripts/configure_zappa.py
+++ b/backend/scripts/configure_zappa.py
@@ -183,111 +183,69 @@ def configure_zappa_settings(
                 else {}
             ),
         },
-        "dev-worker": {
-            "extends": "dev",
-            "stage": "dev-worker",
-            "timeout_seconds": 300,
-            "memory_size": 512,
-            "keep_warm": False,
-            "apigateway_enabled": False,
-            "environment_variables": {
-                **base_env_vars,
-                "ENVIRONMENT": "development",
-                "DEBUG": "false",
-                **(
-                    {"EVALUATION_REQUESTS_QUEUE_URL": eval_requests_queue_url}
-                    if eval_requests_queue_url
-                    else {}
-                ),
-            },
-            "aws_environment_variables": {
-                "DATABASE_URL": db_secret_arn,
-                "SECRET_KEY": django_secret_arn,
-            },
-        },
-        "dev-evaluator": {
-            "extends": "dev",
-            "stage": "dev-evaluator",
-            "timeout_seconds": 300,
-            "memory_size": 512,
-            "keep_warm": False,
-            "apigateway_enabled": False,
-            "vpc_config": {
-                "SubnetIds": [],
-                "SecurityGroupIds": [],
-            },
-            "environment_variables": {
-                **base_env_vars,
-                "ENVIRONMENT": "development",
-                "DEBUG": "false",
-                **(
-                    {"EVALUATION_RESULTS_QUEUE_URL": eval_results_queue_url}
-                    if eval_results_queue_url
-                    else {}
-                ),
-            },
-            "aws_environment_variables": {
-                "SECRET_KEY": django_secret_arn,
-                **(
-                    {"ANTHROPIC_API_KEY": anthropic_secret_arn}
-                    if anthropic_secret_arn
-                    else {}
-                ),
-            },
-        },
-        "prod-worker": {
-            "extends": "prod",
-            "stage": "prod-worker",
-            "timeout_seconds": 300,
-            "memory_size": 512,
-            "keep_warm": False,
-            "apigateway_enabled": False,
-            "environment_variables": {
-                **base_env_vars,
-                "ENVIRONMENT": "production",
-                "DEBUG": "false",
-                **(
-                    {"EVALUATION_REQUESTS_QUEUE_URL": eval_requests_queue_url}
-                    if eval_requests_queue_url
-                    else {}
-                ),
-            },
-            "aws_environment_variables": {
-                "DATABASE_URL": db_secret_arn,
-                "SECRET_KEY": django_secret_arn,
-            },
-        },
-        "prod-evaluator": {
-            "extends": "prod",
-            "stage": "prod-evaluator",
-            "timeout_seconds": 300,
-            "memory_size": 512,
-            "keep_warm": False,
-            "apigateway_enabled": False,
-            "vpc_config": {
-                "SubnetIds": [],
-                "SecurityGroupIds": [],
-            },
-            "environment_variables": {
-                **base_env_vars,
-                "ENVIRONMENT": "production",
-                "DEBUG": "false",
-                **(
-                    {"EVALUATION_RESULTS_QUEUE_URL": eval_results_queue_url}
-                    if eval_results_queue_url
-                    else {}
-                ),
-            },
-            "aws_environment_variables": {
-                "SECRET_KEY": django_secret_arn,
-                **(
-                    {"ANTHROPIC_API_KEY": anthropic_secret_arn}
-                    if anthropic_secret_arn
-                    else {}
-                ),
-            },
-        },
     }
+
+    # Build worker and evaluator stages for each environment
+    envs = {
+        "dev": {"extends": "dev", "env_name": "development"},
+        "prod": {"extends": "prod", "env_name": "production"},
+    }
+    lambda_base: dict[str, Any] = {
+        "timeout_seconds": 300,
+        "memory_size": 512,
+        "keep_warm": False,
+        "apigateway_enabled": False,
+    }
+    for env_key, env_cfg in envs.items():
+        env_vars = {
+            **base_env_vars,
+            "ENVIRONMENT": env_cfg["env_name"],
+            "DEBUG": "false",
+        }
+        # Worker: in VPC, has DB access, dispatches to requests queue
+        settings[f"{env_key}-worker"] = {
+            **lambda_base,
+            "extends": env_cfg["extends"],
+            "stage": f"{env_key}-worker",
+            "environment_variables": {
+                **env_vars,
+                **(
+                    {"EVALUATION_REQUESTS_QUEUE_URL": eval_requests_queue_url}
+                    if eval_requests_queue_url
+                    else {}
+                ),
+            },
+            "aws_environment_variables": {
+                "DATABASE_URL": db_secret_arn,
+                "SECRET_KEY": django_secret_arn,
+            },
+        }
+        # Evaluator: outside VPC, no DB, calls Anthropic API
+        settings[f"{env_key}-evaluator"] = {
+            **lambda_base,
+            "extends": env_cfg["extends"],
+            "stage": f"{env_key}-evaluator",
+            "vpc_config": {
+                "SubnetIds": [],
+                "SecurityGroupIds": [],
+            },
+            "environment_variables": {
+                **env_vars,
+                **(
+                    {"EVALUATION_RESULTS_QUEUE_URL": eval_results_queue_url}
+                    if eval_results_queue_url
+                    else {}
+                ),
+            },
+            "aws_environment_variables": {
+                "SECRET_KEY": django_secret_arn,
+                **(
+                    {"ANTHROPIC_API_KEY": anthropic_secret_arn}
+                    if anthropic_secret_arn
+                    else {}
+                ),
+            },
+        }
 
     config_path = (
         output_path

--- a/backend/scripts/configure_zappa.py
+++ b/backend/scripts/configure_zappa.py
@@ -42,6 +42,8 @@ def configure_zappa_settings(
     domain_name = get_env("DOMAIN_NAME", "")
     certificate_arn = get_env("ACM_CERTIFICATE_ARN", "")
     anthropic_secret_arn = get_env("ANTHROPIC_SECRET_ARN", "")
+    eval_requests_queue_url = get_env("EVALUATION_REQUESTS_QUEUE_URL", "")
+    eval_results_queue_url = get_env("EVALUATION_RESULTS_QUEUE_URL", "")
 
     use_custom_docker = (
         get_env("USE_CUSTOM_DOCKER", "false").lower() == "true"
@@ -188,8 +190,43 @@ def configure_zappa_settings(
             "memory_size": 512,
             "keep_warm": False,
             "apigateway_enabled": False,
+            "environment_variables": {
+                **base_env_vars,
+                "ENVIRONMENT": "development",
+                "DEBUG": "false",
+                **(
+                    {"EVALUATION_REQUESTS_QUEUE_URL": eval_requests_queue_url}
+                    if eval_requests_queue_url
+                    else {}
+                ),
+            },
             "aws_environment_variables": {
                 "DATABASE_URL": db_secret_arn,
+                "SECRET_KEY": django_secret_arn,
+            },
+        },
+        "dev-evaluator": {
+            "extends": "dev",
+            "stage": "dev-evaluator",
+            "timeout_seconds": 300,
+            "memory_size": 512,
+            "keep_warm": False,
+            "apigateway_enabled": False,
+            "vpc_config": {
+                "SubnetIds": [],
+                "SecurityGroupIds": [],
+            },
+            "environment_variables": {
+                **base_env_vars,
+                "ENVIRONMENT": "development",
+                "DEBUG": "false",
+                **(
+                    {"EVALUATION_RESULTS_QUEUE_URL": eval_results_queue_url}
+                    if eval_results_queue_url
+                    else {}
+                ),
+            },
+            "aws_environment_variables": {
                 "SECRET_KEY": django_secret_arn,
                 **(
                     {"ANTHROPIC_API_KEY": anthropic_secret_arn}
@@ -205,8 +242,43 @@ def configure_zappa_settings(
             "memory_size": 512,
             "keep_warm": False,
             "apigateway_enabled": False,
+            "environment_variables": {
+                **base_env_vars,
+                "ENVIRONMENT": "production",
+                "DEBUG": "false",
+                **(
+                    {"EVALUATION_REQUESTS_QUEUE_URL": eval_requests_queue_url}
+                    if eval_requests_queue_url
+                    else {}
+                ),
+            },
             "aws_environment_variables": {
                 "DATABASE_URL": db_secret_arn,
+                "SECRET_KEY": django_secret_arn,
+            },
+        },
+        "prod-evaluator": {
+            "extends": "prod",
+            "stage": "prod-evaluator",
+            "timeout_seconds": 300,
+            "memory_size": 512,
+            "keep_warm": False,
+            "apigateway_enabled": False,
+            "vpc_config": {
+                "SubnetIds": [],
+                "SecurityGroupIds": [],
+            },
+            "environment_variables": {
+                **base_env_vars,
+                "ENVIRONMENT": "production",
+                "DEBUG": "false",
+                **(
+                    {"EVALUATION_RESULTS_QUEUE_URL": eval_results_queue_url}
+                    if eval_results_queue_url
+                    else {}
+                ),
+            },
+            "aws_environment_variables": {
                 "SECRET_KEY": django_secret_arn,
                 **(
                     {"ANTHROPIC_API_KEY": anthropic_secret_arn}

--- a/backend/terramedic/nominations/claim.py
+++ b/backend/terramedic/nominations/claim.py
@@ -1,6 +1,7 @@
-"""Shared nomination-claiming logic used by worker and management command."""
+"""Shared helpers used by the worker, evaluator, and management command."""
 
 from collections.abc import Generator
+from typing import Any
 
 from django.db.models import F
 
@@ -8,6 +9,18 @@ from terramedic.nominations.models import Nomination, NominationStatus
 from terramedic.nominations.skip_checks import should_skip_url
 
 DEFAULT_EVAL_MODEL = "claude-sonnet-4-20250514"
+
+
+def evaluate_org(
+    url: str,
+    model: str,
+    client: Any = None,
+    categories: list[str] | None = None,
+) -> dict[str, Any]:
+    """Lazy-import wrapper — replaced in tests via mock."""
+    from curation.evaluate import evaluate_org as _evaluate_org
+
+    return _evaluate_org(url=url, model=model, client=client, categories=categories)
 
 
 def claim_nominations(limit: int) -> Generator[Nomination]:

--- a/backend/terramedic/nominations/claim.py
+++ b/backend/terramedic/nominations/claim.py
@@ -1,0 +1,47 @@
+"""Shared nomination-claiming logic used by worker and management command."""
+
+from collections.abc import Generator
+
+from django.db.models import F
+
+from terramedic.nominations.models import Nomination, NominationStatus
+from terramedic.nominations.skip_checks import should_skip_url
+
+
+def claim_nominations(limit: int) -> Generator[Nomination]:
+    """Claim queued nominations atomically and yield non-skipped ones.
+
+    For each queued nomination (up to *limit*):
+    1. Atomically set status to EVALUATING and increment attempts.
+    2. Revert to PENDING if the URL should be skipped.
+    3. Yield the nomination if it passed both checks.
+    """
+    nominations = list(
+        Nomination.objects.filter(
+            status=NominationStatus.QUEUED,
+        ).order_by("submitted_at")[:limit],
+    )
+
+    for nomination in nominations:
+        # Atomic claim: only proceed if still queued (prevents
+        # duplicate processing by concurrent workers).
+        claimed = Nomination.objects.filter(
+            pk=nomination.pk,
+            status=NominationStatus.QUEUED,
+        ).update(
+            status=NominationStatus.EVALUATING,
+            evaluation_attempts=F("evaluation_attempts") + 1,
+        )
+        if not claimed:
+            continue
+        nomination.refresh_from_db()
+
+        if should_skip_url(nomination.url):
+            nomination.status = NominationStatus.PENDING
+            nomination.evaluation_attempts -= 1
+            nomination.save(
+                update_fields=["status", "evaluation_attempts"],
+            )
+            continue
+
+        yield nomination

--- a/backend/terramedic/nominations/claim.py
+++ b/backend/terramedic/nominations/claim.py
@@ -7,6 +7,8 @@ from django.db.models import F
 from terramedic.nominations.models import Nomination, NominationStatus
 from terramedic.nominations.skip_checks import should_skip_url
 
+DEFAULT_EVAL_MODEL = "claude-sonnet-4-20250514"
+
 
 def claim_nominations(limit: int) -> Generator[Nomination]:
     """Claim queued nominations atomically and yield non-skipped ones.

--- a/backend/terramedic/nominations/evaluator.py
+++ b/backend/terramedic/nominations/evaluator.py
@@ -1,0 +1,87 @@
+"""Lambda handler for the evaluator (outside VPC).
+
+Triggered by SQS messages on the evaluation-requests queue.
+Fetches org websites, calls the Anthropic API, and sends
+results to the evaluation-results queue.  Has no database access.
+"""
+
+import json
+import logging
+import os
+from typing import Any
+
+import boto3
+
+from terramedic.core.secrets import is_arn, resolve_secret
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_EVAL_MODEL = "claude-sonnet-4-20250514"
+
+
+def evaluate_org(
+    url: str,
+    model: str,
+    client: Any = None,
+    categories: list[str] | None = None,
+) -> dict[str, Any]:
+    """Lazy-import wrapper — replaced in tests via mock."""
+    from curation.evaluate import evaluate_org as _evaluate_org
+
+    return _evaluate_org(url=url, model=model, client=client, categories=categories)
+
+
+def Anthropic(**kwargs: Any) -> Any:  # noqa: N802
+    """Lazy-import wrapper — replaced in tests via mock."""
+    from anthropic import Anthropic as _Anthropic
+
+    return _Anthropic(**kwargs)
+
+
+def handle_evaluation_request(
+    event: dict[str, Any],
+    context: Any = None,
+) -> dict[str, Any]:
+    """Process SQS messages containing evaluation requests."""
+    raw_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    api_key = resolve_secret(raw_key, "key") if is_arn(raw_key) else raw_key
+    client = Anthropic(api_key=api_key)
+
+    results_queue_url = os.environ["EVALUATION_RESULTS_QUEUE_URL"]
+    sqs = boto3.client("sqs")
+
+    for record in event.get("Records", []):
+        body = json.loads(record["body"])
+        nomination_id = body["nomination_id"]
+        url = body["url"]
+        categories = body.get("categories") or None
+        evaluation_attempts = body.get("evaluation_attempts", 1)
+
+        try:
+            data = evaluate_org(
+                url=url,
+                model=_DEFAULT_EVAL_MODEL,
+                client=client,
+                categories=categories,
+            )
+            result_message: dict[str, Any] = {
+                "nomination_id": nomination_id,
+                "evaluation_attempts": evaluation_attempts,
+                "success": True,
+                "data": data,
+            }
+        except Exception:  # noqa: BLE001
+            logger.exception("evaluate_org failed for %s", url)
+            result_message = {
+                "nomination_id": nomination_id,
+                "evaluation_attempts": evaluation_attempts,
+                "success": False,
+                "error": f"evaluate_org failed for {url}",
+            }
+
+        sqs.send_message(
+            QueueUrl=results_queue_url,
+            MessageBody=json.dumps(result_message),
+        )
+
+    return {"status": "ok"}

--- a/backend/terramedic/nominations/evaluator.py
+++ b/backend/terramedic/nominations/evaluator.py
@@ -69,15 +69,9 @@ def handle_evaluation_request(
                 "error": f"evaluate_org failed for {url}",
             }
 
-        try:
-            sqs.send_message(
-                QueueUrl=results_queue_url,
-                MessageBody=json.dumps(result_message),
-            )
-        except Exception:  # noqa: BLE001
-            logger.exception(
-                "Failed to send result to SQS for nomination %s",
-                nomination_id,
-            )
+        sqs.send_message(
+            QueueUrl=results_queue_url,
+            MessageBody=json.dumps(result_message),
+        )
 
     return {"status": "ok"}

--- a/backend/terramedic/nominations/evaluator.py
+++ b/backend/terramedic/nominations/evaluator.py
@@ -44,6 +44,9 @@ def handle_evaluation_request(
 ) -> dict[str, Any]:
     """Process SQS messages containing evaluation requests."""
     raw_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not raw_key:
+        msg = "ANTHROPIC_API_KEY is not set"
+        raise RuntimeError(msg)
     api_key = resolve_secret(raw_key, "key") if is_arn(raw_key) else raw_key
     client = Anthropic(api_key=api_key)
 

--- a/backend/terramedic/nominations/evaluator.py
+++ b/backend/terramedic/nominations/evaluator.py
@@ -82,9 +82,15 @@ def handle_evaluation_request(
                 "error": f"evaluate_org failed for {url}",
             }
 
-        sqs.send_message(
-            QueueUrl=results_queue_url,
-            MessageBody=json.dumps(result_message),
-        )
+        try:
+            sqs.send_message(
+                QueueUrl=results_queue_url,
+                MessageBody=json.dumps(result_message),
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Failed to send result to SQS for nomination %s",
+                nomination_id,
+            )
 
     return {"status": "ok"}

--- a/backend/terramedic/nominations/evaluator.py
+++ b/backend/terramedic/nominations/evaluator.py
@@ -13,21 +13,9 @@ from typing import Any
 import boto3
 
 from terramedic.core.secrets import is_arn, resolve_secret
-from terramedic.nominations.claim import DEFAULT_EVAL_MODEL
+from terramedic.nominations.claim import DEFAULT_EVAL_MODEL, evaluate_org  # noqa: F401
 
 logger = logging.getLogger(__name__)
-
-
-def evaluate_org(
-    url: str,
-    model: str,
-    client: Any = None,
-    categories: list[str] | None = None,
-) -> dict[str, Any]:
-    """Lazy-import wrapper — replaced in tests via mock."""
-    from curation.evaluate import evaluate_org as _evaluate_org
-
-    return _evaluate_org(url=url, model=model, client=client, categories=categories)
 
 
 def Anthropic(**kwargs: Any) -> Any:  # noqa: N802

--- a/backend/terramedic/nominations/evaluator.py
+++ b/backend/terramedic/nominations/evaluator.py
@@ -63,7 +63,7 @@ def handle_evaluation_request(
         try:
             data = evaluate_org(
                 url=url,
-                model=_DEFAULT_EVAL_MODEL,
+                model=os.environ.get("EVAL_MODEL", _DEFAULT_EVAL_MODEL),
                 client=client,
                 categories=categories,
             )

--- a/backend/terramedic/nominations/evaluator.py
+++ b/backend/terramedic/nominations/evaluator.py
@@ -13,10 +13,9 @@ from typing import Any
 import boto3
 
 from terramedic.core.secrets import is_arn, resolve_secret
+from terramedic.nominations.claim import DEFAULT_EVAL_MODEL
 
 logger = logging.getLogger(__name__)
-
-_DEFAULT_EVAL_MODEL = "claude-sonnet-4-20250514"
 
 
 def evaluate_org(
@@ -63,7 +62,7 @@ def handle_evaluation_request(
         try:
             data = evaluate_org(
                 url=url,
-                model=os.environ.get("EVAL_MODEL", _DEFAULT_EVAL_MODEL),
+                model=os.environ.get("EVAL_MODEL", DEFAULT_EVAL_MODEL),
                 client=client,
                 categories=categories,
             )

--- a/backend/terramedic/nominations/management/commands/process_evaluations.py
+++ b/backend/terramedic/nominations/management/commands/process_evaluations.py
@@ -105,7 +105,7 @@ class Command(BaseCommand):
             try:
                 data = evaluate_org(
                     url=nomination.url,
-                    model=_DEFAULT_EVAL_MODEL,
+                    model=os.environ.get("EVAL_MODEL", _DEFAULT_EVAL_MODEL),
                     client=client,
                     categories=nomination.categories or None,
                 )

--- a/backend/terramedic/nominations/management/commands/process_evaluations.py
+++ b/backend/terramedic/nominations/management/commands/process_evaluations.py
@@ -15,25 +15,17 @@ from typing import Any
 from django.core.management.base import BaseCommand, CommandError
 
 from terramedic.core.secrets import is_arn, resolve_secret
-from terramedic.nominations.claim import DEFAULT_EVAL_MODEL, claim_nominations
+from terramedic.nominations.claim import (
+    DEFAULT_EVAL_MODEL,
+    claim_nominations,
+    evaluate_org,  # noqa: F401
+)
 from terramedic.nominations.models import NominationStatus
 from terramedic.organizations.models import OrganizationEvaluation
 
 logger = logging.getLogger(__name__)
 
 _MAX_RETRY_ATTEMPTS = 2
-
-
-def evaluate_org(
-    url: str,
-    model: str,
-    client: Any = None,
-    categories: list[str] | None = None,
-) -> dict[str, Any]:
-    """Lazy import wrapper — replaced in tests via mock."""
-    from curation.evaluate import evaluate_org as _evaluate_org
-
-    return _evaluate_org(url=url, model=model, client=client, categories=categories)
 
 
 def create_anthropic_client(**kwargs: Any) -> Any:

--- a/backend/terramedic/nominations/management/commands/process_evaluations.py
+++ b/backend/terramedic/nominations/management/commands/process_evaluations.py
@@ -15,13 +15,12 @@ from typing import Any
 from django.core.management.base import BaseCommand, CommandError
 
 from terramedic.core.secrets import is_arn, resolve_secret
-from terramedic.nominations.claim import claim_nominations
+from terramedic.nominations.claim import DEFAULT_EVAL_MODEL, claim_nominations
 from terramedic.nominations.models import NominationStatus
 from terramedic.organizations.models import OrganizationEvaluation
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_EVAL_MODEL = "claude-sonnet-4-20250514"
 _MAX_RETRY_ATTEMPTS = 2
 
 
@@ -71,7 +70,7 @@ class Command(BaseCommand):
             try:
                 data = evaluate_org(
                     url=nomination.url,
-                    model=os.environ.get("EVAL_MODEL", _DEFAULT_EVAL_MODEL),
+                    model=os.environ.get("EVAL_MODEL", DEFAULT_EVAL_MODEL),
                     client=client,
                     categories=nomination.categories or None,
                 )

--- a/backend/terramedic/nominations/management/commands/process_evaluations.py
+++ b/backend/terramedic/nominations/management/commands/process_evaluations.py
@@ -13,11 +13,10 @@ import os
 from typing import Any
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db.models import F
 
 from terramedic.core.secrets import is_arn, resolve_secret
-from terramedic.nominations.models import Nomination, NominationStatus
-from terramedic.nominations.skip_checks import should_skip_url
+from terramedic.nominations.claim import claim_nominations
+from terramedic.nominations.models import NominationStatus
 from terramedic.organizations.models import OrganizationEvaluation
 
 logger = logging.getLogger(__name__)
@@ -65,43 +64,10 @@ class Command(BaseCommand):
         client = create_anthropic_client(api_key=api_key)
         limit: int = options["limit"]
 
-        nominations = list(
-            Nomination.objects.filter(
-                status=NominationStatus.QUEUED,
-            ).order_by("submitted_at")[:limit],
-        )
-
-        if not nominations:
-            self.stdout.write("No queued nominations to process.")
-            return
-
         processed = 0
         failed = 0
-        skipped = 0
 
-        for nomination in nominations:
-            # Atomic claim: only proceed if still queued (prevents
-            # duplicate processing by concurrent workers).
-            claimed = Nomination.objects.filter(
-                pk=nomination.pk,
-                status=NominationStatus.QUEUED,
-            ).update(
-                status=NominationStatus.EVALUATING,
-                evaluation_attempts=F("evaluation_attempts") + 1,
-            )
-            if not claimed:
-                continue
-            nomination.refresh_from_db()
-
-            if should_skip_url(nomination.url):
-                nomination.status = NominationStatus.PENDING
-                nomination.evaluation_attempts -= 1
-                nomination.save(
-                    update_fields=["status", "evaluation_attempts"],
-                )
-                skipped += 1
-                continue
-
+        for nomination in claim_nominations(limit):
             try:
                 data = evaluate_org(
                     url=nomination.url,
@@ -132,6 +98,5 @@ class Command(BaseCommand):
             processed += 1
 
         self.stdout.write(
-            f"Processed {processed}, failed {failed}, skipped {skipped} "
-            f"of {len(nominations)} nomination(s).",
+            f"Processed {processed}, failed {failed} nomination(s).",
         )

--- a/backend/terramedic/nominations/tests/conftest.py
+++ b/backend/terramedic/nominations/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures and constants for nominations tests."""
+
+import json
+from typing import Any
+
+EVAL_RESULT: dict[str, Any] = {
+    "org_metadata": {
+        "name": "Test Org",
+        "website_url": "https://example.org",
+    },
+    "evidence_score": {"score": 3},
+    "curator_notes": {
+        "recommendation": "include",
+        "confidence": 80,
+    },
+    "evaluated_by": "claude-sonnet-4-20250514",
+}
+
+
+def make_sqs_event(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build a synthetic SQS event payload for testing."""
+    return {
+        "Records": [
+            {
+                "eventSource": "aws:sqs",
+                "body": json.dumps(record),
+            }
+            for record in records
+        ],
+    }

--- a/backend/terramedic/nominations/tests/conftest.py
+++ b/backend/terramedic/nominations/tests/conftest.py
@@ -28,3 +28,17 @@ def make_sqs_event(records: list[dict[str, Any]]) -> dict[str, Any]:
             for record in records
         ],
     }
+
+
+def make_queued_nomination(
+    url: str = "https://example.org",
+) -> Any:
+    """Create a Nomination in QUEUED status for testing."""
+    from terramedic.nominations.models import Nomination, NominationStatus
+
+    return Nomination.objects.create(
+        url=url,
+        categories=["volunteer"],
+        ip_hash=None,
+        status=NominationStatus.QUEUED,
+    )

--- a/backend/terramedic/nominations/tests/test_claim.py
+++ b/backend/terramedic/nominations/tests/test_claim.py
@@ -5,21 +5,15 @@ from unittest.mock import patch
 import pytest
 
 from terramedic.nominations.claim import claim_nominations
-from terramedic.nominations.models import Nomination, NominationStatus
+from terramedic.nominations.models import NominationStatus
+from terramedic.nominations.tests.conftest import make_queued_nomination
 
 
 @pytest.mark.django_db
 class TestClaimNominations:
-    def _make_queued(self, url: str = "https://example.org") -> Nomination:
-        return Nomination.objects.create(
-            url=url,
-            status=NominationStatus.QUEUED,
-            categories=["volunteer"],
-        )
-
     def test_yields_claimed_nominations(self) -> None:
-        self._make_queued("https://one.org")
-        self._make_queued("https://two.org")
+        make_queued_nomination("https://one.org")
+        make_queued_nomination("https://two.org")
 
         result = list(claim_nominations(limit=10))
 
@@ -28,7 +22,7 @@ class TestClaimNominations:
         assert urls == {"https://one.org", "https://two.org"}
 
     def test_nominations_are_in_evaluating_status(self) -> None:
-        nom = self._make_queued()
+        nom = make_queued_nomination()
 
         claimed = list(claim_nominations(limit=10))
 
@@ -37,14 +31,14 @@ class TestClaimNominations:
         assert nom.status == NominationStatus.EVALUATING
 
     def test_respects_limit(self) -> None:
-        self._make_queued("https://one.org")
-        self._make_queued("https://two.org")
+        make_queued_nomination("https://one.org")
+        make_queued_nomination("https://two.org")
 
         result = list(claim_nominations(limit=1))
         assert len(result) == 1
 
     def test_increments_evaluation_attempts(self) -> None:
-        nom = self._make_queued()
+        nom = make_queued_nomination()
         assert nom.evaluation_attempts == 0
 
         list(claim_nominations(limit=10))
@@ -53,7 +47,7 @@ class TestClaimNominations:
         assert nom.evaluation_attempts == 1
 
     def test_skips_already_claimed_nomination(self) -> None:
-        nom = self._make_queued()
+        nom = make_queued_nomination()
         nom.status = NominationStatus.EVALUATING
         nom.save(update_fields=["status"])
 
@@ -65,7 +59,7 @@ class TestClaimNominations:
         return_value=True,
     )
     def test_skips_skipworthy_url_and_reverts(self, mock_skip: object) -> None:  # noqa: ARG002
-        nom = self._make_queued("https://example.org")
+        nom = make_queued_nomination("https://example.org")
 
         result = list(claim_nominations(limit=10))
 

--- a/backend/terramedic/nominations/tests/test_claim.py
+++ b/backend/terramedic/nominations/tests/test_claim.py
@@ -1,0 +1,79 @@
+"""Tests for the nomination claiming helper."""
+
+from unittest.mock import patch
+
+import pytest
+
+from terramedic.nominations.claim import claim_nominations
+from terramedic.nominations.models import Nomination, NominationStatus
+
+
+@pytest.mark.django_db
+class TestClaimNominations:
+    def _make_queued(self, url: str = "https://example.org") -> Nomination:
+        return Nomination.objects.create(
+            url=url,
+            status=NominationStatus.QUEUED,
+            categories=["volunteer"],
+        )
+
+    def test_yields_claimed_nominations(self) -> None:
+        self._make_queued("https://one.org")
+        self._make_queued("https://two.org")
+
+        result = list(claim_nominations(limit=10))
+
+        assert len(result) == 2
+        urls = {n.url for n in result}
+        assert urls == {"https://one.org", "https://two.org"}
+
+    def test_nominations_are_in_evaluating_status(self) -> None:
+        nom = self._make_queued()
+
+        claimed = list(claim_nominations(limit=10))
+
+        assert len(claimed) == 1
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.EVALUATING
+
+    def test_respects_limit(self) -> None:
+        self._make_queued("https://one.org")
+        self._make_queued("https://two.org")
+
+        result = list(claim_nominations(limit=1))
+        assert len(result) == 1
+
+    def test_increments_evaluation_attempts(self) -> None:
+        nom = self._make_queued()
+        assert nom.evaluation_attempts == 0
+
+        list(claim_nominations(limit=10))
+
+        nom.refresh_from_db()
+        assert nom.evaluation_attempts == 1
+
+    def test_skips_already_claimed_nomination(self) -> None:
+        nom = self._make_queued()
+        nom.status = NominationStatus.EVALUATING
+        nom.save(update_fields=["status"])
+
+        result = list(claim_nominations(limit=10))
+        assert len(result) == 0
+
+    @patch(
+        "terramedic.nominations.claim.should_skip_url",
+        return_value=True,
+    )
+    def test_skips_skipworthy_url_and_reverts(self, mock_skip: object) -> None:  # noqa: ARG002
+        nom = self._make_queued("https://example.org")
+
+        result = list(claim_nominations(limit=10))
+
+        assert len(result) == 0
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.PENDING
+        assert nom.evaluation_attempts == 0
+
+    def test_empty_queue(self) -> None:
+        result = list(claim_nominations(limit=10))
+        assert len(result) == 0

--- a/backend/terramedic/nominations/tests/test_evaluator.py
+++ b/backend/terramedic/nominations/tests/test_evaluator.py
@@ -1,0 +1,217 @@
+"""Tests for the evaluator Lambda handler (outside VPC)."""
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_EVAL_RESULT: dict[str, Any] = {
+    "org_metadata": {
+        "name": "Test Org",
+        "website_url": "https://example.org",
+    },
+    "evidence_score": {"score": 3},
+    "curator_notes": {
+        "recommendation": "include",
+        "confidence": 80,
+    },
+    "evaluated_by": "claude-sonnet-4-20250514",
+}
+
+_EVALUATOR_MODULE = "terramedic.nominations.evaluator"
+_EVALUATE_ORG_PATH = f"{_EVALUATOR_MODULE}.evaluate_org"
+_ANTHROPIC_PATH = f"{_EVALUATOR_MODULE}.Anthropic"
+
+
+def _make_sqs_event(records: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "Records": [
+            {
+                "eventSource": "aws:sqs",
+                "body": json.dumps(record),
+            }
+            for record in records
+        ],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _set_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("EVALUATION_RESULTS_QUEUE_URL", "https://sqs.test/results")
+
+
+class TestHandleEvaluationRequest:
+    @patch(f"{_EVALUATOR_MODULE}.boto3")
+    @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_ANTHROPIC_PATH)
+    def test_successful_evaluation_sends_success_result(
+        self,
+        mock_anthropic: Any,
+        mock_eval: Any,
+        mock_boto3: Any,
+    ) -> None:
+        from terramedic.nominations.evaluator import handle_evaluation_request
+
+        mock_sqs = MagicMock()
+        mock_boto3.client.return_value = mock_sqs
+
+        event = _make_sqs_event([{
+            "nomination_id": 42,
+            "url": "https://example.org",
+            "categories": ["volunteer"],
+            "evaluation_attempts": 1,
+        }])
+        handle_evaluation_request(event)
+
+        mock_sqs.send_message.assert_called_once()
+        call_kwargs = mock_sqs.send_message.call_args[1]
+        assert call_kwargs["QueueUrl"] == "https://sqs.test/results"
+        body = json.loads(call_kwargs["MessageBody"])
+        assert body["nomination_id"] == 42
+        assert body["success"] is True
+        assert body["data"] == _EVAL_RESULT
+        assert body["evaluation_attempts"] == 1
+
+    @patch(f"{_EVALUATOR_MODULE}.boto3")
+    @patch(_EVALUATE_ORG_PATH, side_effect=ValueError("bad URL"))
+    @patch(_ANTHROPIC_PATH)
+    def test_failed_evaluation_sends_failure_result(
+        self,
+        mock_anthropic: Any,
+        mock_eval: Any,
+        mock_boto3: Any,
+    ) -> None:
+        from terramedic.nominations.evaluator import handle_evaluation_request
+
+        mock_sqs = MagicMock()
+        mock_boto3.client.return_value = mock_sqs
+
+        event = _make_sqs_event([{
+            "nomination_id": 42,
+            "url": "https://example.org",
+            "categories": None,
+            "evaluation_attempts": 1,
+        }])
+        handle_evaluation_request(event)
+
+        mock_sqs.send_message.assert_called_once()
+        body = json.loads(mock_sqs.send_message.call_args[1]["MessageBody"])
+        assert body["nomination_id"] == 42
+        assert body["success"] is False
+        assert "error" in body
+
+    @patch(f"{_EVALUATOR_MODULE}.boto3")
+    @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_ANTHROPIC_PATH)
+    def test_passes_url_and_categories_to_evaluate_org(
+        self,
+        mock_anthropic: Any,
+        mock_eval: Any,
+        mock_boto3: Any,
+    ) -> None:
+        from terramedic.nominations.evaluator import handle_evaluation_request
+
+        mock_boto3.client.return_value = MagicMock()
+
+        event = _make_sqs_event([{
+            "nomination_id": 1,
+            "url": "https://special.org",
+            "categories": ["donate", "volunteer"],
+            "evaluation_attempts": 1,
+        }])
+        handle_evaluation_request(event)
+
+        mock_eval.assert_called_once()
+        call_kwargs = mock_eval.call_args[1]
+        assert call_kwargs["url"] == "https://special.org"
+        assert call_kwargs["categories"] == ["donate", "volunteer"]
+
+    @patch(f"{_EVALUATOR_MODULE}.boto3")
+    @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_ANTHROPIC_PATH)
+    def test_processes_multiple_records(
+        self,
+        mock_anthropic: Any,
+        mock_eval: Any,
+        mock_boto3: Any,
+    ) -> None:
+        from terramedic.nominations.evaluator import handle_evaluation_request
+
+        mock_sqs = MagicMock()
+        mock_boto3.client.return_value = mock_sqs
+
+        event = _make_sqs_event([
+            {
+                "nomination_id": 1,
+                "url": "https://one.org",
+                "categories": None,
+                "evaluation_attempts": 1,
+            },
+            {
+                "nomination_id": 2,
+                "url": "https://two.org",
+                "categories": ["donate"],
+                "evaluation_attempts": 1,
+            },
+        ])
+        handle_evaluation_request(event)
+
+        assert mock_eval.call_count == 2
+        assert mock_sqs.send_message.call_count == 2
+
+    @patch(f"{_EVALUATOR_MODULE}.boto3")
+    @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
+    def test_resolves_anthropic_arn(
+        self,
+        mock_eval: Any,
+        mock_boto3: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from terramedic.nominations.evaluator import handle_evaluation_request
+
+        arn = "arn:aws:secretsmanager:us-east-1:123:secret:my-key"
+        monkeypatch.setenv("ANTHROPIC_API_KEY", arn)
+        mock_boto3.client.return_value = MagicMock()
+
+        resolve_path = f"{_EVALUATOR_MODULE}.resolve_secret"
+        anthropic_path = _ANTHROPIC_PATH
+        with (
+            patch(resolve_path, return_value="resolved-key") as mock_resolve,
+            patch(anthropic_path) as mock_anthropic,
+        ):
+            event = _make_sqs_event([{
+                "nomination_id": 1,
+                "url": "https://example.org",
+                "categories": None,
+                "evaluation_attempts": 1,
+            }])
+            handle_evaluation_request(event)
+
+            mock_resolve.assert_called_once_with(arn, "key")
+            mock_anthropic.assert_called_once_with(api_key="resolved-key")
+
+    @patch(f"{_EVALUATOR_MODULE}.boto3")
+    @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_ANTHROPIC_PATH)
+    def test_null_categories_passed_as_none(
+        self,
+        mock_anthropic: Any,
+        mock_eval: Any,
+        mock_boto3: Any,
+    ) -> None:
+        from terramedic.nominations.evaluator import handle_evaluation_request
+
+        mock_boto3.client.return_value = MagicMock()
+
+        event = _make_sqs_event([{
+            "nomination_id": 1,
+            "url": "https://example.org",
+            "categories": None,
+            "evaluation_attempts": 1,
+        }])
+        handle_evaluation_request(event)
+
+        call_kwargs = mock_eval.call_args[1]
+        assert call_kwargs["categories"] is None

--- a/backend/terramedic/nominations/tests/test_evaluator.py
+++ b/backend/terramedic/nominations/tests/test_evaluator.py
@@ -229,6 +229,31 @@ class TestHandleEvaluationRequest:
     @patch(f"{_EVALUATOR_MODULE}.boto3")
     @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
     @patch(_ANTHROPIC_PATH)
+    def test_sqs_send_failure_does_not_crash_lambda(
+        self,
+        mock_anthropic: Any,
+        mock_eval: Any,
+        mock_boto3: Any,
+    ) -> None:
+        from terramedic.nominations.evaluator import handle_evaluation_request
+
+        mock_sqs = MagicMock()
+        mock_sqs.send_message.side_effect = Exception("SQS throttle")
+        mock_boto3.client.return_value = mock_sqs
+
+        event = _make_sqs_event([{
+            "nomination_id": 42,
+            "url": "https://example.org",
+            "categories": ["volunteer"],
+            "evaluation_attempts": 1,
+        }])
+        # Should not raise — SQS failure should be caught and logged
+        result = handle_evaluation_request(event)
+        assert result["status"] == "ok"
+
+    @patch(f"{_EVALUATOR_MODULE}.boto3")
+    @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_ANTHROPIC_PATH)
     def test_null_categories_passed_as_none(
         self,
         mock_anthropic: Any,

--- a/backend/terramedic/nominations/tests/test_evaluator.py
+++ b/backend/terramedic/nominations/tests/test_evaluator.py
@@ -6,34 +6,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-_EVAL_RESULT: dict[str, Any] = {
-    "org_metadata": {
-        "name": "Test Org",
-        "website_url": "https://example.org",
-    },
-    "evidence_score": {"score": 3},
-    "curator_notes": {
-        "recommendation": "include",
-        "confidence": 80,
-    },
-    "evaluated_by": "claude-sonnet-4-20250514",
-}
+from terramedic.nominations.tests.conftest import EVAL_RESULT, make_sqs_event
 
 _EVALUATOR_MODULE = "terramedic.nominations.evaluator"
 _EVALUATE_ORG_PATH = f"{_EVALUATOR_MODULE}.evaluate_org"
 _ANTHROPIC_PATH = f"{_EVALUATOR_MODULE}.Anthropic"
-
-
-def _make_sqs_event(records: list[dict[str, Any]]) -> dict[str, Any]:
-    return {
-        "Records": [
-            {
-                "eventSource": "aws:sqs",
-                "body": json.dumps(record),
-            }
-            for record in records
-        ],
-    }
 
 
 @pytest.fixture(autouse=True)
@@ -44,7 +21,7 @@ def _set_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 class TestHandleEvaluationRequest:
     @patch(f"{_EVALUATOR_MODULE}.boto3")
-    @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVALUATE_ORG_PATH, return_value=EVAL_RESULT)
     @patch(_ANTHROPIC_PATH)
     def test_successful_evaluation_sends_success_result(
         self,
@@ -57,7 +34,7 @@ class TestHandleEvaluationRequest:
         mock_sqs = MagicMock()
         mock_boto3.client.return_value = mock_sqs
 
-        event = _make_sqs_event([{
+        event = make_sqs_event([{
             "nomination_id": 42,
             "url": "https://example.org",
             "categories": ["volunteer"],
@@ -71,7 +48,7 @@ class TestHandleEvaluationRequest:
         body = json.loads(call_kwargs["MessageBody"])
         assert body["nomination_id"] == 42
         assert body["success"] is True
-        assert body["data"] == _EVAL_RESULT
+        assert body["data"] == EVAL_RESULT
         assert body["evaluation_attempts"] == 1
 
     @patch(f"{_EVALUATOR_MODULE}.boto3")
@@ -88,7 +65,7 @@ class TestHandleEvaluationRequest:
         mock_sqs = MagicMock()
         mock_boto3.client.return_value = mock_sqs
 
-        event = _make_sqs_event([{
+        event = make_sqs_event([{
             "nomination_id": 42,
             "url": "https://example.org",
             "categories": None,
@@ -103,7 +80,7 @@ class TestHandleEvaluationRequest:
         assert "error" in body
 
     @patch(f"{_EVALUATOR_MODULE}.boto3")
-    @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVALUATE_ORG_PATH, return_value=EVAL_RESULT)
     @patch(_ANTHROPIC_PATH)
     def test_passes_url_and_categories_to_evaluate_org(
         self,
@@ -115,7 +92,7 @@ class TestHandleEvaluationRequest:
 
         mock_boto3.client.return_value = MagicMock()
 
-        event = _make_sqs_event([{
+        event = make_sqs_event([{
             "nomination_id": 1,
             "url": "https://special.org",
             "categories": ["donate", "volunteer"],
@@ -129,7 +106,7 @@ class TestHandleEvaluationRequest:
         assert call_kwargs["categories"] == ["donate", "volunteer"]
 
     @patch(f"{_EVALUATOR_MODULE}.boto3")
-    @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVALUATE_ORG_PATH, return_value=EVAL_RESULT)
     @patch(_ANTHROPIC_PATH)
     def test_processes_multiple_records(
         self,
@@ -142,7 +119,7 @@ class TestHandleEvaluationRequest:
         mock_sqs = MagicMock()
         mock_boto3.client.return_value = mock_sqs
 
-        event = _make_sqs_event([
+        event = make_sqs_event([
             {
                 "nomination_id": 1,
                 "url": "https://one.org",
@@ -162,7 +139,7 @@ class TestHandleEvaluationRequest:
         assert mock_sqs.send_message.call_count == 2
 
     @patch(f"{_EVALUATOR_MODULE}.boto3")
-    @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVALUATE_ORG_PATH, return_value=EVAL_RESULT)
     def test_resolves_anthropic_arn(
         self,
         mock_eval: Any,
@@ -181,7 +158,7 @@ class TestHandleEvaluationRequest:
             patch(resolve_path, return_value="resolved-key") as mock_resolve,
             patch(anthropic_path) as mock_anthropic,
         ):
-            event = _make_sqs_event([{
+            event = make_sqs_event([{
                 "nomination_id": 1,
                 "url": "https://example.org",
                 "categories": None,
@@ -200,7 +177,7 @@ class TestHandleEvaluationRequest:
 
         monkeypatch.delenv("ANTHROPIC_API_KEY")
 
-        event = _make_sqs_event([{
+        event = make_sqs_event([{
             "nomination_id": 1,
             "url": "https://example.org",
             "categories": None,
@@ -217,7 +194,7 @@ class TestHandleEvaluationRequest:
 
         monkeypatch.setenv("ANTHROPIC_API_KEY", "")
 
-        event = _make_sqs_event([{
+        event = make_sqs_event([{
             "nomination_id": 1,
             "url": "https://example.org",
             "categories": None,
@@ -227,7 +204,7 @@ class TestHandleEvaluationRequest:
             handle_evaluation_request(event)
 
     @patch(f"{_EVALUATOR_MODULE}.boto3")
-    @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVALUATE_ORG_PATH, return_value=EVAL_RESULT)
     @patch(_ANTHROPIC_PATH)
     def test_sqs_send_failure_does_not_crash_lambda(
         self,
@@ -241,7 +218,7 @@ class TestHandleEvaluationRequest:
         mock_sqs.send_message.side_effect = Exception("SQS throttle")
         mock_boto3.client.return_value = mock_sqs
 
-        event = _make_sqs_event([{
+        event = make_sqs_event([{
             "nomination_id": 42,
             "url": "https://example.org",
             "categories": ["volunteer"],
@@ -252,7 +229,7 @@ class TestHandleEvaluationRequest:
         assert result["status"] == "ok"
 
     @patch(f"{_EVALUATOR_MODULE}.boto3")
-    @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVALUATE_ORG_PATH, return_value=EVAL_RESULT)
     @patch(_ANTHROPIC_PATH)
     def test_null_categories_passed_as_none(
         self,
@@ -264,7 +241,7 @@ class TestHandleEvaluationRequest:
 
         mock_boto3.client.return_value = MagicMock()
 
-        event = _make_sqs_event([{
+        event = make_sqs_event([{
             "nomination_id": 1,
             "url": "https://example.org",
             "categories": None,

--- a/backend/terramedic/nominations/tests/test_evaluator.py
+++ b/backend/terramedic/nominations/tests/test_evaluator.py
@@ -192,6 +192,40 @@ class TestHandleEvaluationRequest:
             mock_resolve.assert_called_once_with(arn, "key")
             mock_anthropic.assert_called_once_with(api_key="resolved-key")
 
+    def test_raises_when_api_key_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from terramedic.nominations.evaluator import handle_evaluation_request
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY")
+
+        event = _make_sqs_event([{
+            "nomination_id": 1,
+            "url": "https://example.org",
+            "categories": None,
+            "evaluation_attempts": 1,
+        }])
+        with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY is not set"):
+            handle_evaluation_request(event)
+
+    def test_raises_when_api_key_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from terramedic.nominations.evaluator import handle_evaluation_request
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+
+        event = _make_sqs_event([{
+            "nomination_id": 1,
+            "url": "https://example.org",
+            "categories": None,
+            "evaluation_attempts": 1,
+        }])
+        with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY is not set"):
+            handle_evaluation_request(event)
+
     @patch(f"{_EVALUATOR_MODULE}.boto3")
     @patch(_EVALUATE_ORG_PATH, return_value=_EVAL_RESULT)
     @patch(_ANTHROPIC_PATH)

--- a/backend/terramedic/nominations/tests/test_evaluator.py
+++ b/backend/terramedic/nominations/tests/test_evaluator.py
@@ -231,6 +231,32 @@ class TestHandleEvaluationRequest:
     @patch(f"{_EVALUATOR_MODULE}.boto3")
     @patch(_EVALUATE_ORG_PATH, return_value=EVAL_RESULT)
     @patch(_ANTHROPIC_PATH)
+    def test_uses_eval_model_env_var_when_set(
+        self,
+        mock_anthropic: Any,
+        mock_eval: Any,
+        mock_boto3: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from terramedic.nominations.evaluator import handle_evaluation_request
+
+        monkeypatch.setenv("EVAL_MODEL", "claude-opus-4-20250514")
+        mock_boto3.client.return_value = MagicMock()
+
+        event = make_sqs_event([{
+            "nomination_id": 1,
+            "url": "https://example.org",
+            "categories": None,
+            "evaluation_attempts": 1,
+        }])
+        handle_evaluation_request(event)
+
+        call_kwargs = mock_eval.call_args[1]
+        assert call_kwargs["model"] == "claude-opus-4-20250514"
+
+    @patch(f"{_EVALUATOR_MODULE}.boto3")
+    @patch(_EVALUATE_ORG_PATH, return_value=EVAL_RESULT)
+    @patch(_ANTHROPIC_PATH)
     def test_null_categories_passed_as_none(
         self,
         mock_anthropic: Any,

--- a/backend/terramedic/nominations/tests/test_evaluator.py
+++ b/backend/terramedic/nominations/tests/test_evaluator.py
@@ -206,12 +206,14 @@ class TestHandleEvaluationRequest:
     @patch(f"{_EVALUATOR_MODULE}.boto3")
     @patch(_EVALUATE_ORG_PATH, return_value=EVAL_RESULT)
     @patch(_ANTHROPIC_PATH)
-    def test_sqs_send_failure_does_not_crash_lambda(
+    def test_sqs_send_failure_propagates_for_retry(
         self,
         mock_anthropic: Any,
         mock_eval: Any,
         mock_boto3: Any,
     ) -> None:
+        """SQS send failure must propagate so the message stays on the
+        requests queue and is retried by the redrive policy."""
         from terramedic.nominations.evaluator import handle_evaluation_request
 
         mock_sqs = MagicMock()
@@ -224,9 +226,8 @@ class TestHandleEvaluationRequest:
             "categories": ["volunteer"],
             "evaluation_attempts": 1,
         }])
-        # Should not raise — SQS failure should be caught and logged
-        result = handle_evaluation_request(event)
-        assert result["status"] == "ok"
+        with pytest.raises(Exception, match="SQS throttle"):
+            handle_evaluation_request(event)
 
     @patch(f"{_EVALUATOR_MODULE}.boto3")
     @patch(_EVALUATE_ORG_PATH, return_value=EVAL_RESULT)

--- a/backend/terramedic/nominations/tests/test_process_evaluations.py
+++ b/backend/terramedic/nominations/tests/test_process_evaluations.py
@@ -7,24 +7,12 @@ from django.core.management import call_command
 from django.utils import timezone
 
 from terramedic.nominations.models import Nomination, NominationStatus
+from terramedic.nominations.tests.conftest import EVAL_RESULT
 from terramedic.organizations.models import (
     Organization,
     OrganizationEvaluation,
     ReviewStatus,
 )
-
-_EVAL_RESULT: dict[str, Any] = {
-    "org_metadata": {
-        "name": "Test Org",
-        "website_url": "https://example.org",
-    },
-    "evidence_score": {"score": 3},
-    "curator_notes": {
-        "recommendation": "include",
-        "confidence": 80,
-    },
-    "evaluated_by": "claude-sonnet-4-20250514",
-}
 
 _COMMAND = "process_evaluations"
 
@@ -58,7 +46,7 @@ def _make_queued_nomination(
 @pytest.mark.django_db
 class TestProcessEvaluationsSuccess:
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_processes_queued_nomination(
         self,
         mock_eval: Any,
@@ -70,7 +58,7 @@ class TestProcessEvaluationsSuccess:
         assert nom.status == NominationStatus.EVALUATED
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_creates_evaluation_record(
         self,
         mock_eval: Any,
@@ -84,7 +72,7 @@ class TestProcessEvaluationsSuccess:
         assert ev.nomination_id == nom.pk
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_evaluation_stores_correct_fields(
         self,
         mock_eval: Any,
@@ -99,7 +87,7 @@ class TestProcessEvaluationsSuccess:
         assert ev.ai_confidence == 80
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_passes_url_and_categories(
         self,
         mock_eval: Any,
@@ -113,7 +101,7 @@ class TestProcessEvaluationsSuccess:
         assert call_kwargs[1]["categories"] == ["volunteer"]
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_sets_evaluating_during_processing(
         self,
         mock_eval: Any,
@@ -125,14 +113,14 @@ class TestProcessEvaluationsSuccess:
         def capture_status(**kwargs: Any) -> dict[str, Any]:
             nom.refresh_from_db()
             statuses_during.append(nom.status)
-            return _EVAL_RESULT
+            return EVAL_RESULT
 
         mock_eval.side_effect = capture_status
         call_command(_COMMAND)
         assert statuses_during == [NominationStatus.EVALUATING]
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_processes_in_submission_order(
         self,
         mock_eval: Any,
@@ -145,7 +133,7 @@ class TestProcessEvaluationsSuccess:
         assert urls == [nom1.url, nom2.url]
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_respects_limit(
         self,
         mock_eval: Any,
@@ -205,7 +193,7 @@ class TestProcessEvaluationsFailure:
         mock_eval: Any,
         mock_anthropic: Any,
     ) -> None:
-        mock_eval.side_effect = [ValueError("bad"), _EVAL_RESULT]
+        mock_eval.side_effect = [ValueError("bad"), EVAL_RESULT]
         nom1 = _make_queued_nomination(url="https://bad.org")
         nom2 = _make_queued_nomination(url="https://good.org")
         call_command(_COMMAND)
@@ -218,7 +206,7 @@ class TestProcessEvaluationsFailure:
 @pytest.mark.django_db
 class TestProcessEvaluationsEdgeCases:
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_empty_queue_exits_cleanly(
         self,
         mock_eval: Any,
@@ -238,7 +226,7 @@ class TestProcessEvaluationsEdgeCases:
             call_command(_COMMAND)
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_resolves_arn_via_secrets_manager(
         self,
         mock_eval: Any,
@@ -261,7 +249,7 @@ class TestProcessEvaluationsEdgeCases:
         mock_anthropic.assert_called_once_with(api_key="resolved-key")
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_plain_key_used_directly(
         self,
         mock_eval: Any,
@@ -279,7 +267,7 @@ class TestProcessEvaluationsSkips:
     """Worker skips queued nominations that shouldn't be evaluated."""
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_skips_url_with_active_evaluation(
         self,
         mock_eval: Any,
@@ -298,7 +286,7 @@ class TestProcessEvaluationsSkips:
         mock_eval.assert_not_called()
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_skips_url_with_approved_evaluation(
         self,
         mock_eval: Any,
@@ -317,7 +305,7 @@ class TestProcessEvaluationsSkips:
         mock_eval.assert_not_called()
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_skips_url_matching_existing_org(
         self,
         mock_eval: Any,
@@ -339,7 +327,7 @@ class TestProcessEvaluationsSkips:
         mock_eval.assert_not_called()
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_skips_recently_rejected_url(
         self,
         mock_eval: Any,
@@ -358,7 +346,7 @@ class TestProcessEvaluationsSkips:
         mock_eval.assert_not_called()
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_allows_old_rejected_url(
         self,
         mock_eval: Any,
@@ -379,7 +367,7 @@ class TestProcessEvaluationsSkips:
         assert nom.status == NominationStatus.EVALUATED
 
     @patch(_ANTHROPIC_PATH)
-    @patch(_EVAL_ORG_PATH, return_value=_EVAL_RESULT)
+    @patch(_EVAL_ORG_PATH, return_value=EVAL_RESULT)
     def test_skip_does_not_count_as_failure(
         self,
         mock_eval: Any,

--- a/backend/terramedic/nominations/tests/test_process_evaluations.py
+++ b/backend/terramedic/nominations/tests/test_process_evaluations.py
@@ -6,8 +6,8 @@ import pytest
 from django.core.management import call_command
 from django.utils import timezone
 
-from terramedic.nominations.models import Nomination, NominationStatus
-from terramedic.nominations.tests.conftest import EVAL_RESULT
+from terramedic.nominations.models import NominationStatus
+from terramedic.nominations.tests.conftest import EVAL_RESULT, make_queued_nomination
 from terramedic.organizations.models import (
     Organization,
     OrganizationEvaluation,
@@ -32,16 +32,6 @@ _ANTHROPIC_PATH = (
 )
 
 
-def _make_queued_nomination(
-    url: str = "https://example.org",
-) -> Nomination:
-    return Nomination.objects.create(
-        url=url,
-        categories=["volunteer"],
-        ip_hash=None,
-        status=NominationStatus.QUEUED,
-    )
-
 
 @pytest.mark.django_db
 class TestProcessEvaluationsSuccess:
@@ -52,7 +42,7 @@ class TestProcessEvaluationsSuccess:
         mock_eval: Any,
         mock_anthropic: Any,
     ) -> None:
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         call_command(_COMMAND)
         nom.refresh_from_db()
         assert nom.status == NominationStatus.EVALUATED
@@ -64,7 +54,7 @@ class TestProcessEvaluationsSuccess:
         mock_eval: Any,
         mock_anthropic: Any,
     ) -> None:
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         call_command(_COMMAND)
         assert OrganizationEvaluation.objects.count() == 1
         ev = OrganizationEvaluation.objects.first()
@@ -78,7 +68,7 @@ class TestProcessEvaluationsSuccess:
         mock_eval: Any,
         mock_anthropic: Any,
     ) -> None:
-        _make_queued_nomination()
+        make_queued_nomination()
         call_command(_COMMAND)
         ev = OrganizationEvaluation.objects.first()
         assert ev is not None
@@ -93,7 +83,7 @@ class TestProcessEvaluationsSuccess:
         mock_eval: Any,
         mock_anthropic: Any,
     ) -> None:
-        _make_queued_nomination(url="https://special.org")
+        make_queued_nomination(url="https://special.org")
         call_command(_COMMAND)
         mock_eval.assert_called_once()
         call_kwargs = mock_eval.call_args
@@ -107,7 +97,7 @@ class TestProcessEvaluationsSuccess:
         mock_eval: Any,
         mock_anthropic: Any,
     ) -> None:
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         statuses_during: list[str] = []
 
         def capture_status(**kwargs: Any) -> dict[str, Any]:
@@ -126,8 +116,8 @@ class TestProcessEvaluationsSuccess:
         mock_eval: Any,
         mock_anthropic: Any,
     ) -> None:
-        nom1 = _make_queued_nomination(url="https://first.org")
-        nom2 = _make_queued_nomination(url="https://second.org")
+        nom1 = make_queued_nomination(url="https://first.org")
+        nom2 = make_queued_nomination(url="https://second.org")
         call_command(_COMMAND)
         urls = [c[1]["url"] for c in mock_eval.call_args_list]
         assert urls == [nom1.url, nom2.url]
@@ -139,8 +129,8 @@ class TestProcessEvaluationsSuccess:
         mock_eval: Any,
         mock_anthropic: Any,
     ) -> None:
-        _make_queued_nomination(url="https://first.org")
-        _make_queued_nomination(url="https://second.org")
+        make_queued_nomination(url="https://first.org")
+        make_queued_nomination(url="https://second.org")
         call_command(_COMMAND, "--limit", "1")
         assert mock_eval.call_count == 1
 
@@ -154,7 +144,7 @@ class TestProcessEvaluationsFailure:
         mock_eval: Any,
         mock_anthropic: Any,
     ) -> None:
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         call_command(_COMMAND)
         nom.refresh_from_db()
         assert nom.status == NominationStatus.QUEUED
@@ -167,7 +157,7 @@ class TestProcessEvaluationsFailure:
         mock_eval: Any,
         mock_anthropic: Any,
     ) -> None:
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         nom.evaluation_attempts = 1
         nom.save(update_fields=["evaluation_attempts"])
         call_command(_COMMAND)
@@ -182,7 +172,7 @@ class TestProcessEvaluationsFailure:
         mock_eval: Any,
         mock_anthropic: Any,
     ) -> None:
-        _make_queued_nomination()
+        make_queued_nomination()
         call_command(_COMMAND)
         assert OrganizationEvaluation.objects.count() == 0
 
@@ -194,8 +184,8 @@ class TestProcessEvaluationsFailure:
         mock_anthropic: Any,
     ) -> None:
         mock_eval.side_effect = [ValueError("bad"), EVAL_RESULT]
-        nom1 = _make_queued_nomination(url="https://bad.org")
-        nom2 = _make_queued_nomination(url="https://good.org")
+        nom1 = make_queued_nomination(url="https://bad.org")
+        nom2 = make_queued_nomination(url="https://good.org")
         call_command(_COMMAND)
         nom1.refresh_from_db()
         nom2.refresh_from_db()
@@ -237,7 +227,7 @@ class TestProcessEvaluationsEdgeCases:
         resolves it to the actual key before creating the client."""
         arn = "arn:aws:secretsmanager:us-east-1:123:secret:my-key"
         monkeypatch.setenv("ANTHROPIC_API_KEY", arn)
-        _make_queued_nomination()
+        make_queued_nomination()
 
         resolve_path = (
             "terramedic.nominations.management.commands"
@@ -257,7 +247,7 @@ class TestProcessEvaluationsEdgeCases:
     ) -> None:
         """When ANTHROPIC_API_KEY is a plain string (local dev),
         it is passed directly to the Anthropic client."""
-        _make_queued_nomination()
+        make_queued_nomination()
         call_command(_COMMAND)
         mock_anthropic.assert_called_once_with(api_key="test-key")
 
@@ -279,7 +269,7 @@ class TestProcessEvaluationsSkips:
             },
             status=ReviewStatus.PENDING,
         )
-        nom = _make_queued_nomination(url="https://example.org")
+        nom = make_queued_nomination(url="https://example.org")
         call_command(_COMMAND)
         nom.refresh_from_db()
         assert nom.status == NominationStatus.PENDING
@@ -298,7 +288,7 @@ class TestProcessEvaluationsSkips:
             },
             status=ReviewStatus.APPROVED,
         )
-        nom = _make_queued_nomination(url="https://example.org")
+        nom = make_queued_nomination(url="https://example.org")
         call_command(_COMMAND)
         nom.refresh_from_db()
         assert nom.status == NominationStatus.PENDING
@@ -320,7 +310,7 @@ class TestProcessEvaluationsSkips:
         org.action_text = "Support"
         org.save()
 
-        nom = _make_queued_nomination(url="https://example.org")
+        nom = make_queued_nomination(url="https://example.org")
         call_command(_COMMAND)
         nom.refresh_from_db()
         assert nom.status == NominationStatus.PENDING
@@ -339,7 +329,7 @@ class TestProcessEvaluationsSkips:
             },
             status=ReviewStatus.REJECTED,
         )
-        nom = _make_queued_nomination(url="https://example.org")
+        nom = make_queued_nomination(url="https://example.org")
         call_command(_COMMAND)
         nom.refresh_from_db()
         assert nom.status == NominationStatus.PENDING
@@ -361,7 +351,7 @@ class TestProcessEvaluationsSkips:
         OrganizationEvaluation.objects.filter(pk=ev.pk).update(
             created_at=timezone.now() - datetime.timedelta(days=91),
         )
-        nom = _make_queued_nomination(url="https://example.org")
+        nom = make_queued_nomination(url="https://example.org")
         call_command(_COMMAND)
         nom.refresh_from_db()
         assert nom.status == NominationStatus.EVALUATED
@@ -380,7 +370,7 @@ class TestProcessEvaluationsSkips:
             },
             status=ReviewStatus.PENDING,
         )
-        nom = _make_queued_nomination(url="https://example.org")
+        nom = make_queued_nomination(url="https://example.org")
         call_command(_COMMAND)
         nom.refresh_from_db()
         assert nom.evaluation_attempts == 0

--- a/backend/terramedic/nominations/tests/test_worker.py
+++ b/backend/terramedic/nominations/tests/test_worker.py
@@ -213,6 +213,25 @@ class TestHandleDispatch:
         urls = [json.loads(c[1]["MessageBody"])["url"] for c in calls]
         assert urls == ["https://first.org", "https://second.org"]
 
+    @patch(f"{_WORKER_MODULE}.boto3")
+    def test_sqs_send_failure_reverts_nomination(
+        self, mock_boto3: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from terramedic.nominations.worker import _handle_dispatch
+
+        monkeypatch.setenv("EVALUATION_REQUESTS_QUEUE_URL", "https://sqs.test/queue")
+        mock_sqs = MagicMock()
+        mock_sqs.send_message.side_effect = Exception("SQS throttle")
+        mock_boto3.client.return_value = mock_sqs
+
+        nom = _make_queued_nomination()
+        result = _handle_dispatch(_make_eventbridge_event())
+
+        assert result["dispatched"] == 0
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.QUEUED
+        assert nom.evaluation_attempts == 0
+
 
 # ── Results ──────────────────────────────────────────────────────
 

--- a/backend/terramedic/nominations/tests/test_worker.py
+++ b/backend/terramedic/nominations/tests/test_worker.py
@@ -1,0 +1,370 @@
+"""Tests for the refactored worker Lambda handler (dispatch + results)."""
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from terramedic.nominations.models import Nomination, NominationStatus
+from terramedic.organizations.models import (
+    OrganizationEvaluation,
+    ReviewStatus,
+)
+
+_EVAL_RESULT: dict[str, Any] = {
+    "org_metadata": {
+        "name": "Test Org",
+        "website_url": "https://example.org",
+    },
+    "evidence_score": {"score": 3},
+    "curator_notes": {
+        "recommendation": "include",
+        "confidence": 80,
+    },
+    "evaluated_by": "claude-sonnet-4-20250514",
+}
+
+_WORKER_MODULE = "terramedic.nominations.worker"
+
+
+def _make_queued_nomination(
+    url: str = "https://example.org",
+) -> Nomination:
+    return Nomination.objects.create(
+        url=url,
+        categories=["volunteer"],
+        ip_hash=None,
+        status=NominationStatus.QUEUED,
+    )
+
+
+def _make_eventbridge_event(limit: int = 10) -> dict[str, Any]:
+    """Simulate an EventBridge scheduled event (via Zappa command envelope)."""
+    return {"limit": limit}
+
+
+def _make_sqs_results_event(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Simulate an SQS event with evaluation results."""
+    return {
+        "Records": [
+            {
+                "eventSource": "aws:sqs",
+                "body": json.dumps(record),
+            }
+            for record in records
+        ],
+    }
+
+
+# ── Routing ──────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestEventRouting:
+    @patch(f"{_WORKER_MODULE}._handle_dispatch")
+    def test_eventbridge_event_routes_to_dispatch(
+        self, mock_dispatch: Any,
+    ) -> None:
+        from terramedic.nominations.worker import process_evaluation_queue
+
+        mock_dispatch.return_value = {"status": "ok"}
+        process_evaluation_queue({"limit": 10})
+        mock_dispatch.assert_called_once()
+
+    @patch(f"{_WORKER_MODULE}._handle_results")
+    def test_sqs_event_routes_to_results(
+        self, mock_results: Any,
+    ) -> None:
+        from terramedic.nominations.worker import process_evaluation_queue
+
+        mock_results.return_value = {"status": "ok"}
+        event = _make_sqs_results_event([{"nomination_id": 1}])
+        process_evaluation_queue(event)
+        mock_results.assert_called_once()
+
+    @patch(f"{_WORKER_MODULE}._handle_dispatch")
+    def test_empty_event_routes_to_dispatch(
+        self, mock_dispatch: Any,
+    ) -> None:
+        from terramedic.nominations.worker import process_evaluation_queue
+
+        mock_dispatch.return_value = {"status": "ok"}
+        process_evaluation_queue(None)
+        mock_dispatch.assert_called_once()
+
+
+# ── Dispatch ─────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestHandleDispatch:
+    @patch(f"{_WORKER_MODULE}.boto3")
+    def test_sends_sqs_message_for_queued_nomination(
+        self, mock_boto3: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from terramedic.nominations.worker import _handle_dispatch
+
+        monkeypatch.setenv("EVALUATION_REQUESTS_QUEUE_URL", "https://sqs.test/queue")
+        mock_sqs = MagicMock()
+        mock_boto3.client.return_value = mock_sqs
+
+        nom = _make_queued_nomination()
+        _handle_dispatch(_make_eventbridge_event())
+
+        mock_sqs.send_message.assert_called_once()
+        call_kwargs = mock_sqs.send_message.call_args[1]
+        assert call_kwargs["QueueUrl"] == "https://sqs.test/queue"
+        body = json.loads(call_kwargs["MessageBody"])
+        assert body["nomination_id"] == nom.pk
+        assert body["url"] == "https://example.org"
+        assert body["categories"] == ["volunteer"]
+        assert body["evaluation_attempts"] == 1
+
+    @patch(f"{_WORKER_MODULE}.boto3")
+    def test_claims_nomination_atomically(
+        self, mock_boto3: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from terramedic.nominations.worker import _handle_dispatch
+
+        monkeypatch.setenv("EVALUATION_REQUESTS_QUEUE_URL", "https://sqs.test/queue")
+        mock_boto3.client.return_value = MagicMock()
+
+        nom = _make_queued_nomination()
+        _handle_dispatch(_make_eventbridge_event())
+
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.EVALUATING
+        assert nom.evaluation_attempts == 1
+
+    @patch(f"{_WORKER_MODULE}.boto3")
+    def test_skips_nomination_with_active_eval(
+        self, mock_boto3: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from terramedic.nominations.worker import _handle_dispatch
+
+        monkeypatch.setenv("EVALUATION_REQUESTS_QUEUE_URL", "https://sqs.test/queue")
+        mock_sqs = MagicMock()
+        mock_boto3.client.return_value = mock_sqs
+
+        OrganizationEvaluation.objects.create(
+            evaluation_data={
+                "org_metadata": {"website_url": "https://example.org"},
+            },
+            status=ReviewStatus.PENDING,
+        )
+        nom = _make_queued_nomination(url="https://example.org")
+        result = _handle_dispatch(_make_eventbridge_event())
+
+        assert result["skipped"] == 1
+        assert result["dispatched"] == 0
+        mock_sqs.send_message.assert_not_called()
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.PENDING
+        assert nom.evaluation_attempts == 0
+
+    @patch(f"{_WORKER_MODULE}.boto3")
+    def test_respects_limit(
+        self, mock_boto3: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from terramedic.nominations.worker import _handle_dispatch
+
+        monkeypatch.setenv("EVALUATION_REQUESTS_QUEUE_URL", "https://sqs.test/queue")
+        mock_sqs = MagicMock()
+        mock_boto3.client.return_value = mock_sqs
+
+        _make_queued_nomination(url="https://first.org")
+        _make_queued_nomination(url="https://second.org")
+        result = _handle_dispatch({"limit": 1})
+
+        assert result["dispatched"] == 1
+        assert mock_sqs.send_message.call_count == 1
+
+    @patch(f"{_WORKER_MODULE}.boto3")
+    def test_empty_queue_dispatches_nothing(
+        self, mock_boto3: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from terramedic.nominations.worker import _handle_dispatch
+
+        monkeypatch.setenv("EVALUATION_REQUESTS_QUEUE_URL", "https://sqs.test/queue")
+        mock_sqs = MagicMock()
+        mock_boto3.client.return_value = mock_sqs
+
+        result = _handle_dispatch(_make_eventbridge_event())
+
+        assert result["dispatched"] == 0
+        mock_sqs.send_message.assert_not_called()
+
+    @patch(f"{_WORKER_MODULE}.boto3")
+    def test_dispatches_in_submission_order(
+        self, mock_boto3: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from terramedic.nominations.worker import _handle_dispatch
+
+        monkeypatch.setenv("EVALUATION_REQUESTS_QUEUE_URL", "https://sqs.test/queue")
+        mock_sqs = MagicMock()
+        mock_boto3.client.return_value = mock_sqs
+
+        _make_queued_nomination(url="https://first.org")
+        _make_queued_nomination(url="https://second.org")
+        _handle_dispatch(_make_eventbridge_event())
+
+        calls = mock_sqs.send_message.call_args_list
+        urls = [json.loads(c[1]["MessageBody"])["url"] for c in calls]
+        assert urls == ["https://first.org", "https://second.org"]
+
+
+# ── Results ──────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestHandleResults:
+    def test_creates_evaluation_on_success(self) -> None:
+        from terramedic.nominations.worker import _handle_results
+
+        nom = _make_queued_nomination()
+        nom.status = NominationStatus.EVALUATING
+        nom.save(update_fields=["status"])
+
+        event = _make_sqs_results_event([{
+            "nomination_id": nom.pk,
+            "evaluation_attempts": 1,
+            "success": True,
+            "data": _EVAL_RESULT,
+        }])
+        result = _handle_results(event)
+
+        assert result["processed"] == 1
+        assert OrganizationEvaluation.objects.count() == 1
+        ev = OrganizationEvaluation.objects.first()
+        assert ev is not None
+        assert ev.nomination == nom
+        assert ev.ai_model == "claude-sonnet-4-20250514"
+        assert ev.ai_recommendation == "include"
+        assert ev.ai_confidence == 80
+
+    def test_sets_nomination_evaluated_on_success(self) -> None:
+        """Django signal should update nomination status to EVALUATED."""
+        from terramedic.nominations.worker import _handle_results
+
+        nom = _make_queued_nomination()
+        nom.status = NominationStatus.EVALUATING
+        nom.save(update_fields=["status"])
+
+        event = _make_sqs_results_event([{
+            "nomination_id": nom.pk,
+            "evaluation_attempts": 1,
+            "success": True,
+            "data": _EVAL_RESULT,
+        }])
+        _handle_results(event)
+
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.EVALUATED
+
+    def test_reverts_to_queued_on_first_failure(self) -> None:
+        from terramedic.nominations.worker import _handle_results
+
+        nom = _make_queued_nomination()
+        nom.status = NominationStatus.EVALUATING
+        nom.evaluation_attempts = 1
+        nom.save(update_fields=["status", "evaluation_attempts"])
+
+        event = _make_sqs_results_event([{
+            "nomination_id": nom.pk,
+            "evaluation_attempts": 1,
+            "success": False,
+            "error": "evaluate_org failed",
+        }])
+        result = _handle_results(event)
+
+        assert result["failed"] == 1
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.QUEUED
+
+    def test_sets_failed_on_second_failure(self) -> None:
+        from terramedic.nominations.worker import _handle_results
+
+        nom = _make_queued_nomination()
+        nom.status = NominationStatus.EVALUATING
+        nom.evaluation_attempts = 2
+        nom.save(update_fields=["status", "evaluation_attempts"])
+
+        event = _make_sqs_results_event([{
+            "nomination_id": nom.pk,
+            "evaluation_attempts": 2,
+            "success": False,
+            "error": "evaluate_org failed",
+        }])
+        result = _handle_results(event)
+
+        assert result["failed"] == 1
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.FAILED
+
+    def test_handles_missing_nomination(self) -> None:
+        from terramedic.nominations.worker import _handle_results
+
+        event = _make_sqs_results_event([{
+            "nomination_id": 99999,
+            "evaluation_attempts": 1,
+            "success": True,
+            "data": _EVAL_RESULT,
+        }])
+        # Should not raise
+        result = _handle_results(event)
+        assert result["processed"] == 0
+        assert OrganizationEvaluation.objects.count() == 0
+
+    def test_processes_multiple_results(self) -> None:
+        from terramedic.nominations.worker import _handle_results
+
+        nom1 = _make_queued_nomination(url="https://one.org")
+        nom1.status = NominationStatus.EVALUATING
+        nom1.save(update_fields=["status"])
+
+        nom2 = _make_queued_nomination(url="https://two.org")
+        nom2.status = NominationStatus.EVALUATING
+        nom2.save(update_fields=["status"])
+
+        result2 = dict(_EVAL_RESULT)
+        result2["org_metadata"] = {
+            "name": "Org Two",
+            "website_url": "https://two.org",
+        }
+
+        event = _make_sqs_results_event([
+            {
+                "nomination_id": nom1.pk,
+                "evaluation_attempts": 1,
+                "success": True,
+                "data": _EVAL_RESULT,
+            },
+            {
+                "nomination_id": nom2.pk,
+                "evaluation_attempts": 1,
+                "success": True,
+                "data": result2,
+            },
+        ])
+        result = _handle_results(event)
+
+        assert result["processed"] == 2
+        assert OrganizationEvaluation.objects.count() == 2
+
+    def test_failure_creates_no_evaluation(self) -> None:
+        from terramedic.nominations.worker import _handle_results
+
+        nom = _make_queued_nomination()
+        nom.status = NominationStatus.EVALUATING
+        nom.save(update_fields=["status"])
+
+        event = _make_sqs_results_event([{
+            "nomination_id": nom.pk,
+            "evaluation_attempts": 1,
+            "success": False,
+            "error": "evaluate_org failed",
+        }])
+        _handle_results(event)
+
+        assert OrganizationEvaluation.objects.count() == 0

--- a/backend/terramedic/nominations/tests/test_worker.py
+++ b/backend/terramedic/nominations/tests/test_worker.py
@@ -263,7 +263,7 @@ class TestHandleResults:
         assert ev.ai_confidence == 80
 
     def test_sets_nomination_evaluated_on_success(self) -> None:
-        """Django signal should update nomination status to EVALUATED."""
+        """Worker explicitly sets nomination status to EVALUATED."""
         from terramedic.nominations.worker import _handle_results
 
         nom = _make_queued_nomination()

--- a/backend/terramedic/nominations/tests/test_worker.py
+++ b/backend/terramedic/nominations/tests/test_worker.py
@@ -371,6 +371,26 @@ class TestHandleResults:
         assert result["processed"] == 2
         assert OrganizationEvaluation.objects.count() == 2
 
+    def test_duplicate_result_is_idempotent(self) -> None:
+        from terramedic.nominations.worker import _handle_results
+
+        nom = _make_queued_nomination()
+        nom.status = NominationStatus.EVALUATING
+        nom.save(update_fields=["status"])
+
+        record = {
+            "nomination_id": nom.pk,
+            "evaluation_attempts": 1,
+            "success": True,
+            "data": _EVAL_RESULT,
+        }
+        # Process the same result twice (SQS at-least-once delivery)
+        _handle_results(_make_sqs_results_event([record]))
+        result = _handle_results(_make_sqs_results_event([record]))
+
+        assert result["processed"] == 0  # second delivery is a no-op
+        assert OrganizationEvaluation.objects.count() == 1
+
     def test_failure_creates_no_evaluation(self) -> None:
         from terramedic.nominations.worker import _handle_results
 

--- a/backend/terramedic/nominations/tests/test_worker.py
+++ b/backend/terramedic/nominations/tests/test_worker.py
@@ -7,23 +7,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from terramedic.nominations.models import Nomination, NominationStatus
+from terramedic.nominations.tests.conftest import EVAL_RESULT, make_sqs_event
 from terramedic.organizations.models import (
     OrganizationEvaluation,
     ReviewStatus,
 )
-
-_EVAL_RESULT: dict[str, Any] = {
-    "org_metadata": {
-        "name": "Test Org",
-        "website_url": "https://example.org",
-    },
-    "evidence_score": {"score": 3},
-    "curator_notes": {
-        "recommendation": "include",
-        "confidence": 80,
-    },
-    "evaluated_by": "claude-sonnet-4-20250514",
-}
 
 _WORKER_MODULE = "terramedic.nominations.worker"
 
@@ -42,19 +30,6 @@ def _make_queued_nomination(
 def _make_eventbridge_event(limit: int = 10) -> dict[str, Any]:
     """Simulate an EventBridge scheduled event (via Zappa command envelope)."""
     return {"limit": limit}
-
-
-def _make_sqs_results_event(records: list[dict[str, Any]]) -> dict[str, Any]:
-    """Simulate an SQS event with evaluation results."""
-    return {
-        "Records": [
-            {
-                "eventSource": "aws:sqs",
-                "body": json.dumps(record),
-            }
-            for record in records
-        ],
-    }
 
 
 # ── Routing ──────────────────────────────────────────────────────
@@ -79,7 +54,7 @@ class TestEventRouting:
         from terramedic.nominations.worker import process_evaluation_queue
 
         mock_results.return_value = {"status": "ok"}
-        event = _make_sqs_results_event([{"nomination_id": 1}])
+        event = make_sqs_event([{"nomination_id": 1}])
         process_evaluation_queue(event)
         mock_results.assert_called_once()
 
@@ -245,11 +220,11 @@ class TestHandleResults:
         nom.status = NominationStatus.EVALUATING
         nom.save(update_fields=["status"])
 
-        event = _make_sqs_results_event([{
+        event = make_sqs_event([{
             "nomination_id": nom.pk,
             "evaluation_attempts": 1,
             "success": True,
-            "data": _EVAL_RESULT,
+            "data": EVAL_RESULT,
         }])
         result = _handle_results(event)
 
@@ -270,11 +245,11 @@ class TestHandleResults:
         nom.status = NominationStatus.EVALUATING
         nom.save(update_fields=["status"])
 
-        event = _make_sqs_results_event([{
+        event = make_sqs_event([{
             "nomination_id": nom.pk,
             "evaluation_attempts": 1,
             "success": True,
-            "data": _EVAL_RESULT,
+            "data": EVAL_RESULT,
         }])
         _handle_results(event)
 
@@ -289,7 +264,7 @@ class TestHandleResults:
         nom.evaluation_attempts = 1
         nom.save(update_fields=["status", "evaluation_attempts"])
 
-        event = _make_sqs_results_event([{
+        event = make_sqs_event([{
             "nomination_id": nom.pk,
             "evaluation_attempts": 1,
             "success": False,
@@ -309,7 +284,7 @@ class TestHandleResults:
         nom.evaluation_attempts = 2
         nom.save(update_fields=["status", "evaluation_attempts"])
 
-        event = _make_sqs_results_event([{
+        event = make_sqs_event([{
             "nomination_id": nom.pk,
             "evaluation_attempts": 2,
             "success": False,
@@ -324,11 +299,11 @@ class TestHandleResults:
     def test_handles_missing_nomination(self) -> None:
         from terramedic.nominations.worker import _handle_results
 
-        event = _make_sqs_results_event([{
+        event = make_sqs_event([{
             "nomination_id": 99999,
             "evaluation_attempts": 1,
             "success": True,
-            "data": _EVAL_RESULT,
+            "data": EVAL_RESULT,
         }])
         # Should not raise
         result = _handle_results(event)
@@ -346,18 +321,18 @@ class TestHandleResults:
         nom2.status = NominationStatus.EVALUATING
         nom2.save(update_fields=["status"])
 
-        result2 = dict(_EVAL_RESULT)
+        result2 = dict(EVAL_RESULT)
         result2["org_metadata"] = {
             "name": "Org Two",
             "website_url": "https://two.org",
         }
 
-        event = _make_sqs_results_event([
+        event = make_sqs_event([
             {
                 "nomination_id": nom1.pk,
                 "evaluation_attempts": 1,
                 "success": True,
-                "data": _EVAL_RESULT,
+                "data": EVAL_RESULT,
             },
             {
                 "nomination_id": nom2.pk,
@@ -382,11 +357,11 @@ class TestHandleResults:
             "nomination_id": nom.pk,
             "evaluation_attempts": 1,
             "success": True,
-            "data": _EVAL_RESULT,
+            "data": EVAL_RESULT,
         }
         # Process the same result twice (SQS at-least-once delivery)
-        _handle_results(_make_sqs_results_event([record]))
-        result = _handle_results(_make_sqs_results_event([record]))
+        _handle_results(make_sqs_event([record]))
+        result = _handle_results(make_sqs_event([record]))
 
         assert result["processed"] == 0  # second delivery is a no-op
         assert OrganizationEvaluation.objects.count() == 1
@@ -398,7 +373,7 @@ class TestHandleResults:
         nom.status = NominationStatus.EVALUATING
         nom.save(update_fields=["status"])
 
-        event = _make_sqs_results_event([{
+        event = make_sqs_event([{
             "nomination_id": nom.pk,
             "evaluation_attempts": 1,
             "success": False,

--- a/backend/terramedic/nominations/tests/test_worker.py
+++ b/backend/terramedic/nominations/tests/test_worker.py
@@ -6,25 +6,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from terramedic.nominations.models import Nomination, NominationStatus
-from terramedic.nominations.tests.conftest import EVAL_RESULT, make_sqs_event
+from terramedic.nominations.models import NominationStatus
+from terramedic.nominations.tests.conftest import (
+    EVAL_RESULT,
+    make_queued_nomination,
+    make_sqs_event,
+)
 from terramedic.organizations.models import (
     OrganizationEvaluation,
     ReviewStatus,
 )
 
 _WORKER_MODULE = "terramedic.nominations.worker"
-
-
-def _make_queued_nomination(
-    url: str = "https://example.org",
-) -> Nomination:
-    return Nomination.objects.create(
-        url=url,
-        categories=["volunteer"],
-        ip_hash=None,
-        status=NominationStatus.QUEUED,
-    )
 
 
 def _make_eventbridge_event(limit: int = 10) -> dict[str, Any]:
@@ -84,7 +77,7 @@ class TestHandleDispatch:
         mock_sqs = MagicMock()
         mock_boto3.client.return_value = mock_sqs
 
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         _handle_dispatch(_make_eventbridge_event())
 
         mock_sqs.send_message.assert_called_once()
@@ -105,7 +98,7 @@ class TestHandleDispatch:
         monkeypatch.setenv("EVALUATION_REQUESTS_QUEUE_URL", "https://sqs.test/queue")
         mock_boto3.client.return_value = MagicMock()
 
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         _handle_dispatch(_make_eventbridge_event())
 
         nom.refresh_from_db()
@@ -128,7 +121,7 @@ class TestHandleDispatch:
             },
             status=ReviewStatus.PENDING,
         )
-        nom = _make_queued_nomination(url="https://example.org")
+        nom = make_queued_nomination(url="https://example.org")
         result = _handle_dispatch(_make_eventbridge_event())
 
         assert result["dispatched"] == 0
@@ -147,8 +140,8 @@ class TestHandleDispatch:
         mock_sqs = MagicMock()
         mock_boto3.client.return_value = mock_sqs
 
-        _make_queued_nomination(url="https://first.org")
-        _make_queued_nomination(url="https://second.org")
+        make_queued_nomination(url="https://first.org")
+        make_queued_nomination(url="https://second.org")
         result = _handle_dispatch({"limit": 1})
 
         assert result["dispatched"] == 1
@@ -179,8 +172,8 @@ class TestHandleDispatch:
         mock_sqs = MagicMock()
         mock_boto3.client.return_value = mock_sqs
 
-        _make_queued_nomination(url="https://first.org")
-        _make_queued_nomination(url="https://second.org")
+        make_queued_nomination(url="https://first.org")
+        make_queued_nomination(url="https://second.org")
         _handle_dispatch(_make_eventbridge_event())
 
         calls = mock_sqs.send_message.call_args_list
@@ -198,7 +191,7 @@ class TestHandleDispatch:
         mock_sqs.send_message.side_effect = Exception("SQS throttle")
         mock_boto3.client.return_value = mock_sqs
 
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         result = _handle_dispatch(_make_eventbridge_event())
 
         assert result["dispatched"] == 0
@@ -227,7 +220,7 @@ class TestHandleResults:
     def test_creates_evaluation_on_success(self) -> None:
         from terramedic.nominations.worker import _handle_results
 
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         nom.status = NominationStatus.EVALUATING
         nom.save(update_fields=["status"])
 
@@ -252,7 +245,7 @@ class TestHandleResults:
         """Worker explicitly sets nomination status to EVALUATED."""
         from terramedic.nominations.worker import _handle_results
 
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         nom.status = NominationStatus.EVALUATING
         nom.save(update_fields=["status"])
 
@@ -270,7 +263,7 @@ class TestHandleResults:
     def test_reverts_to_queued_on_first_failure(self) -> None:
         from terramedic.nominations.worker import _handle_results
 
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         nom.status = NominationStatus.EVALUATING
         nom.evaluation_attempts = 1
         nom.save(update_fields=["status", "evaluation_attempts"])
@@ -290,7 +283,7 @@ class TestHandleResults:
     def test_sets_failed_on_second_failure(self) -> None:
         from terramedic.nominations.worker import _handle_results
 
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         nom.status = NominationStatus.EVALUATING
         nom.evaluation_attempts = 2
         nom.save(update_fields=["status", "evaluation_attempts"])
@@ -324,11 +317,11 @@ class TestHandleResults:
     def test_processes_multiple_results(self) -> None:
         from terramedic.nominations.worker import _handle_results
 
-        nom1 = _make_queued_nomination(url="https://one.org")
+        nom1 = make_queued_nomination(url="https://one.org")
         nom1.status = NominationStatus.EVALUATING
         nom1.save(update_fields=["status"])
 
-        nom2 = _make_queued_nomination(url="https://two.org")
+        nom2 = make_queued_nomination(url="https://two.org")
         nom2.status = NominationStatus.EVALUATING
         nom2.save(update_fields=["status"])
 
@@ -360,7 +353,7 @@ class TestHandleResults:
     def test_duplicate_result_is_idempotent(self) -> None:
         from terramedic.nominations.worker import _handle_results
 
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         nom.status = NominationStatus.EVALUATING
         nom.save(update_fields=["status"])
 
@@ -380,7 +373,7 @@ class TestHandleResults:
     def test_failure_creates_no_evaluation(self) -> None:
         from terramedic.nominations.worker import _handle_results
 
-        nom = _make_queued_nomination()
+        nom = make_queued_nomination()
         nom.status = NominationStatus.EVALUATING
         nom.save(update_fields=["status"])
 

--- a/backend/terramedic/nominations/tests/test_worker.py
+++ b/backend/terramedic/nominations/tests/test_worker.py
@@ -206,6 +206,18 @@ class TestHandleDispatch:
         assert nom.status == NominationStatus.QUEUED
         assert nom.evaluation_attempts == 0
 
+    def test_raises_when_queue_url_missing(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from terramedic.nominations.worker import _handle_dispatch
+
+        monkeypatch.delenv("EVALUATION_REQUESTS_QUEUE_URL", raising=False)
+
+        with pytest.raises(
+            RuntimeError, match="EVALUATION_REQUESTS_QUEUE_URL is not set",
+        ):
+            _handle_dispatch(_make_eventbridge_event())
+
 
 # ── Results ──────────────────────────────────────────────────────
 

--- a/backend/terramedic/nominations/tests/test_worker.py
+++ b/backend/terramedic/nominations/tests/test_worker.py
@@ -131,7 +131,6 @@ class TestHandleDispatch:
         nom = _make_queued_nomination(url="https://example.org")
         result = _handle_dispatch(_make_eventbridge_event())
 
-        assert result["skipped"] == 1
         assert result["dispatched"] == 0
         mock_sqs.send_message.assert_not_called()
         nom.refresh_from_db()

--- a/backend/terramedic/nominations/worker.py
+++ b/backend/terramedic/nominations/worker.py
@@ -43,7 +43,10 @@ def process_evaluation_queue(
 def _handle_dispatch(event: dict[str, Any]) -> dict[str, Any]:
     """Query DB for queued nominations and send to SQS."""
     limit = max(1, min(int(event.get("limit", 10)), 50))
-    queue_url = os.environ["EVALUATION_REQUESTS_QUEUE_URL"]
+    queue_url = os.environ.get("EVALUATION_REQUESTS_QUEUE_URL", "")
+    if not queue_url:
+        msg = "EVALUATION_REQUESTS_QUEUE_URL is not set"
+        raise RuntimeError(msg)
     sqs = boto3.client("sqs")
 
     dispatched = 0

--- a/backend/terramedic/nominations/worker.py
+++ b/backend/terramedic/nominations/worker.py
@@ -15,10 +15,9 @@ import os
 from typing import Any
 
 import boto3
-from django.db.models import F
 
+from terramedic.nominations.claim import claim_nominations
 from terramedic.nominations.models import Nomination, NominationStatus
-from terramedic.nominations.skip_checks import should_skip_url
 from terramedic.organizations.models import OrganizationEvaluation
 
 logger = logging.getLogger(__name__)
@@ -47,37 +46,9 @@ def _handle_dispatch(event: dict[str, Any]) -> dict[str, Any]:
     queue_url = os.environ["EVALUATION_REQUESTS_QUEUE_URL"]
     sqs = boto3.client("sqs")
 
-    nominations = list(
-        Nomination.objects.filter(
-            status=NominationStatus.QUEUED,
-        ).order_by("submitted_at")[:limit],
-    )
-
     dispatched = 0
-    skipped = 0
 
-    for nomination in nominations:
-        # Atomic claim: only proceed if still queued.
-        claimed = Nomination.objects.filter(
-            pk=nomination.pk,
-            status=NominationStatus.QUEUED,
-        ).update(
-            status=NominationStatus.EVALUATING,
-            evaluation_attempts=F("evaluation_attempts") + 1,
-        )
-        if not claimed:
-            continue
-        nomination.refresh_from_db()
-
-        if should_skip_url(nomination.url):
-            nomination.status = NominationStatus.PENDING
-            nomination.evaluation_attempts -= 1
-            nomination.save(
-                update_fields=["status", "evaluation_attempts"],
-            )
-            skipped += 1
-            continue
-
+    for nomination in claim_nominations(limit):
         try:
             sqs.send_message(
                 QueueUrl=queue_url,
@@ -101,11 +72,8 @@ def _handle_dispatch(event: dict[str, Any]) -> dict[str, Any]:
             continue
         dispatched += 1
 
-    logger.info(
-        "Dispatched %d, skipped %d of %d nomination(s).",
-        dispatched, skipped, len(nominations),
-    )
-    return {"status": "ok", "dispatched": dispatched, "skipped": skipped}
+    logger.info("Dispatched %d nomination(s).", dispatched)
+    return {"status": "ok", "dispatched": dispatched}
 
 
 def _handle_results(event: dict[str, Any]) -> dict[str, Any]:

--- a/backend/terramedic/nominations/worker.py
+++ b/backend/terramedic/nominations/worker.py
@@ -139,6 +139,11 @@ def _handle_results(event: dict[str, Any]) -> dict[str, Any]:
                 },
             )
             if created:
+                # Explicit status update (the post_save signal in
+                # organizations.signals also does this, but keeping
+                # it here makes the worker self-contained).
+                nomination.status = NominationStatus.EVALUATED
+                nomination.save(update_fields=["status"])
                 processed += 1
             else:
                 logger.info(

--- a/backend/terramedic/nominations/worker.py
+++ b/backend/terramedic/nominations/worker.py
@@ -78,15 +78,27 @@ def _handle_dispatch(event: dict[str, Any]) -> dict[str, Any]:
             skipped += 1
             continue
 
-        sqs.send_message(
-            QueueUrl=queue_url,
-            MessageBody=json.dumps({
-                "nomination_id": nomination.pk,
-                "url": nomination.url,
-                "categories": nomination.categories,
-                "evaluation_attempts": nomination.evaluation_attempts,
-            }),
-        )
+        try:
+            sqs.send_message(
+                QueueUrl=queue_url,
+                MessageBody=json.dumps({
+                    "nomination_id": nomination.pk,
+                    "url": nomination.url,
+                    "categories": nomination.categories,
+                    "evaluation_attempts": nomination.evaluation_attempts,
+                }),
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Failed to dispatch nomination %s to SQS.",
+                nomination.pk,
+            )
+            nomination.status = NominationStatus.QUEUED
+            nomination.evaluation_attempts -= 1
+            nomination.save(
+                update_fields=["status", "evaluation_attempts"],
+            )
+            continue
         dispatched += 1
 
     logger.info(

--- a/backend/terramedic/nominations/worker.py
+++ b/backend/terramedic/nominations/worker.py
@@ -127,14 +127,25 @@ def _handle_results(event: dict[str, Any]) -> dict[str, Any]:
         if body.get("success"):
             data = body["data"]
             curator_notes = data.get("curator_notes", {})
-            OrganizationEvaluation.objects.create(
-                evaluation_data=data,
-                ai_model=data.get("evaluated_by", ""),
-                ai_recommendation=curator_notes.get("recommendation", ""),
-                ai_confidence=curator_notes.get("confidence"),
+            _, created = OrganizationEvaluation.objects.get_or_create(
                 nomination=nomination,
+                defaults={
+                    "evaluation_data": data,
+                    "ai_model": data.get("evaluated_by", ""),
+                    "ai_recommendation": curator_notes.get(
+                        "recommendation", "",
+                    ),
+                    "ai_confidence": curator_notes.get("confidence"),
+                },
             )
-            processed += 1
+            if created:
+                processed += 1
+            else:
+                logger.info(
+                    "Evaluation already exists for nomination %s; "
+                    "skipping duplicate result.",
+                    nomination_id,
+                )
         else:
             if evaluation_attempts >= _MAX_RETRY_ATTEMPTS:
                 nomination.status = NominationStatus.FAILED

--- a/backend/terramedic/nominations/worker.py
+++ b/backend/terramedic/nominations/worker.py
@@ -1,23 +1,135 @@
-"""Lambda handler for processing the evaluation queue.
+"""Lambda handler for the evaluation worker (in VPC).
 
-Invoked asynchronously by the admin action via boto3, or directly
-via ``zappa invoke``.
+Handles two triggers:
+
+- **EventBridge** (scheduled): queries DB for queued nominations,
+  claims them, runs skip checks, and dispatches to the
+  evaluation-requests SQS queue.
+- **SQS** (evaluation-results): writes evaluation results to the
+  database and updates nomination status.
 """
 
+import json
+import logging
+import os
 from typing import Any
 
-from django.core.management import call_command
+import boto3
+from django.db.models import F
+
+from terramedic.nominations.models import Nomination, NominationStatus
+from terramedic.nominations.skip_checks import should_skip_url
+from terramedic.organizations.models import OrganizationEvaluation
+
+logger = logging.getLogger(__name__)
+
+_MAX_RETRY_ATTEMPTS = 2
 
 
 def process_evaluation_queue(
     event: dict[str, Any] | None = None,
     context: Any = None,
 ) -> dict[str, Any]:
-    """Process queued nominations.
-
-    Accepts an optional ``limit`` key in the event payload.
-    """
+    """Route to dispatch or results handler based on event source."""
     event = event or {}
+
+    if "Records" in event and event["Records"]:
+        source = event["Records"][0].get("eventSource", "")
+        if source == "aws:sqs":
+            return _handle_results(event)
+
+    return _handle_dispatch(event)
+
+
+def _handle_dispatch(event: dict[str, Any]) -> dict[str, Any]:
+    """Query DB for queued nominations and send to SQS."""
     limit = max(1, min(int(event.get("limit", 10)), 50))
-    call_command("process_evaluations", "--limit", str(limit))
-    return {"status": "ok", "limit": limit}
+    queue_url = os.environ["EVALUATION_REQUESTS_QUEUE_URL"]
+    sqs = boto3.client("sqs")
+
+    nominations = list(
+        Nomination.objects.filter(
+            status=NominationStatus.QUEUED,
+        ).order_by("submitted_at")[:limit],
+    )
+
+    dispatched = 0
+    skipped = 0
+
+    for nomination in nominations:
+        # Atomic claim: only proceed if still queued.
+        claimed = Nomination.objects.filter(
+            pk=nomination.pk,
+            status=NominationStatus.QUEUED,
+        ).update(
+            status=NominationStatus.EVALUATING,
+            evaluation_attempts=F("evaluation_attempts") + 1,
+        )
+        if not claimed:
+            continue
+        nomination.refresh_from_db()
+
+        if should_skip_url(nomination.url):
+            nomination.status = NominationStatus.PENDING
+            nomination.evaluation_attempts -= 1
+            nomination.save(
+                update_fields=["status", "evaluation_attempts"],
+            )
+            skipped += 1
+            continue
+
+        sqs.send_message(
+            QueueUrl=queue_url,
+            MessageBody=json.dumps({
+                "nomination_id": nomination.pk,
+                "url": nomination.url,
+                "categories": nomination.categories,
+                "evaluation_attempts": nomination.evaluation_attempts,
+            }),
+        )
+        dispatched += 1
+
+    logger.info(
+        "Dispatched %d, skipped %d of %d nomination(s).",
+        dispatched, skipped, len(nominations),
+    )
+    return {"status": "ok", "dispatched": dispatched, "skipped": skipped}
+
+
+def _handle_results(event: dict[str, Any]) -> dict[str, Any]:
+    """Process evaluation results from SQS."""
+    processed = 0
+    failed = 0
+
+    for record in event.get("Records", []):
+        body = json.loads(record["body"])
+        nomination_id = body["nomination_id"]
+        evaluation_attempts = body.get("evaluation_attempts", 1)
+
+        try:
+            nomination = Nomination.objects.get(pk=nomination_id)
+        except Nomination.DoesNotExist:
+            logger.warning("Nomination %s not found, skipping", nomination_id)
+            continue
+
+        if body.get("success"):
+            data = body["data"]
+            curator_notes = data.get("curator_notes", {})
+            OrganizationEvaluation.objects.create(
+                evaluation_data=data,
+                ai_model=data.get("evaluated_by", ""),
+                ai_recommendation=curator_notes.get("recommendation", ""),
+                ai_confidence=curator_notes.get("confidence"),
+                nomination=nomination,
+            )
+            processed += 1
+        else:
+            if evaluation_attempts >= _MAX_RETRY_ATTEMPTS:
+                nomination.status = NominationStatus.FAILED
+            else:
+                nomination.status = NominationStatus.QUEUED
+            nomination.save(update_fields=["status"])
+            failed += 1
+
+    logger.info("Processed %d, failed %d result(s).", processed, failed)
+    return {"status": "ok", "processed": processed, "failed": failed}

--- a/terraform/modules/zappa/main.tf
+++ b/terraform/modules/zappa/main.tf
@@ -233,6 +233,17 @@ resource "aws_iam_policy" "zappa_deployment" {
           "iam:PassRole"
         ]
         Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.prefix}-*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:SendMessage",
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:GetQueueUrl"
+        ]
+        Resource = "arn:aws:sqs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${var.prefix}-evaluation-*"
       }
     ]
   })
@@ -293,7 +304,8 @@ resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
 }
 
 locals {
-  worker_function_name = "${var.prefix}-worker"
+  worker_function_name    = "${var.prefix}-worker"
+  evaluator_function_name = "${var.prefix}-evaluator"
 }
 
 # EventBridge scheduled rule to trigger the worker Lambda
@@ -328,4 +340,69 @@ resource "aws_lambda_permission" "eventbridge_worker" {
   function_name = local.worker_function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.worker_schedule[0].arn
+}
+
+# ── SQS queues for worker ↔ evaluator communication ─────────────
+
+resource "aws_sqs_queue" "evaluation_requests_dlq" {
+  count = var.worker_schedule_expression != "" ? 1 : 0
+
+  name                      = "${var.prefix}-evaluation-requests-dlq"
+  message_retention_seconds = 604800 # 7 days
+  tags                      = var.tags
+}
+
+resource "aws_sqs_queue" "evaluation_requests" {
+  count = var.worker_schedule_expression != "" ? 1 : 0
+
+  name                       = "${var.prefix}-evaluation-requests"
+  visibility_timeout_seconds = 360 # > evaluator Lambda timeout (300s)
+  message_retention_seconds  = 86400
+  tags                       = var.tags
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.evaluation_requests_dlq[0].arn
+    maxReceiveCount     = 2
+  })
+}
+
+resource "aws_sqs_queue" "evaluation_results_dlq" {
+  count = var.worker_schedule_expression != "" ? 1 : 0
+
+  name                      = "${var.prefix}-evaluation-results-dlq"
+  message_retention_seconds = 604800 # 7 days
+  tags                      = var.tags
+}
+
+resource "aws_sqs_queue" "evaluation_results" {
+  count = var.worker_schedule_expression != "" ? 1 : 0
+
+  name                       = "${var.prefix}-evaluation-results"
+  visibility_timeout_seconds = 60
+  message_retention_seconds  = 86400
+  tags                       = var.tags
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.evaluation_results_dlq[0].arn
+    maxReceiveCount     = 3
+  })
+}
+
+# SQS → Lambda event source mappings
+resource "aws_lambda_event_source_mapping" "evaluator_sqs_trigger" {
+  count = var.worker_schedule_expression != "" ? 1 : 0
+
+  event_source_arn = aws_sqs_queue.evaluation_requests[0].arn
+  function_name    = "arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.current.account_id}:function:${local.evaluator_function_name}"
+  batch_size       = 1 # One evaluation at a time (each takes ~30s)
+  enabled          = true
+}
+
+resource "aws_lambda_event_source_mapping" "worker_results_sqs_trigger" {
+  count = var.worker_schedule_expression != "" ? 1 : 0
+
+  event_source_arn = aws_sqs_queue.evaluation_results[0].arn
+  function_name    = "arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.current.account_id}:function:${local.worker_function_name}"
+  batch_size       = 10
+  enabled          = true
 }

--- a/terraform/modules/zappa/main.tf
+++ b/terraform/modules/zappa/main.tf
@@ -362,7 +362,7 @@ resource "aws_sqs_queue" "evaluation_requests" {
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.evaluation_requests_dlq[0].arn
-    maxReceiveCount     = 2
+    maxReceiveCount     = 2 # Low: each attempt calls the Anthropic API (~$)
   })
 }
 
@@ -384,7 +384,7 @@ resource "aws_sqs_queue" "evaluation_results" {
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.evaluation_results_dlq[0].arn
-    maxReceiveCount     = 3
+    maxReceiveCount     = 3 # Higher: worker retries are cheap (DB writes only)
   })
 }
 

--- a/terraform/modules/zappa/main.tf
+++ b/terraform/modules/zappa/main.tf
@@ -378,7 +378,7 @@ resource "aws_sqs_queue" "evaluation_results" {
   count = var.worker_schedule_expression != "" ? 1 : 0
 
   name                       = "${var.prefix}-evaluation-results"
-  visibility_timeout_seconds = 60
+  visibility_timeout_seconds = 360 # > worker Lambda timeout (300s)
   message_retention_seconds  = 86400
   tags                       = var.tags
 

--- a/terraform/modules/zappa/outputs.tf
+++ b/terraform/modules/zappa/outputs.tf
@@ -27,3 +27,13 @@ output "worker_schedule_rule_arn" {
   description = "ARN of the EventBridge rule that triggers the worker Lambda (null if not configured)"
   value       = length(aws_cloudwatch_event_rule.worker_schedule) > 0 ? aws_cloudwatch_event_rule.worker_schedule[0].arn : null
 }
+
+output "evaluation_requests_queue_url" {
+  description = "URL of the SQS queue for evaluation requests (null if not configured)"
+  value       = length(aws_sqs_queue.evaluation_requests) > 0 ? aws_sqs_queue.evaluation_requests[0].url : null
+}
+
+output "evaluation_results_queue_url" {
+  description = "URL of the SQS queue for evaluation results (null if not configured)"
+  value       = length(aws_sqs_queue.evaluation_results) > 0 ? aws_sqs_queue.evaluation_results[0].url : null
+}


### PR DESCRIPTION
## Summary

- Split the single worker Lambda into two Lambdas communicating via SQS, eliminating the need for a NAT Gateway (~$32/mo)
- **Worker** (in VPC): dispatches queued nominations to SQS, writes evaluation results back to DB
- **Evaluator** (no VPC): fetches org websites, calls Anthropic API, sends results to SQS

## Architecture

```
EventBridge (5 min) → Worker (VPC) → [evaluation-requests SQS]
                                            ↓
                                      Evaluator (no VPC)
                                            ↓
                      Worker (VPC) ← [evaluation-results SQS]
                            ↓
                        DB write
```

## Changes

### Backend
- **`evaluator.py`** — New Lambda handler for the evaluator (outside VPC). Receives SQS messages, resolves Anthropic API key from Secrets Manager, calls `evaluate_org()`, sends results (success or failure) to the results queue.
- **`worker.py`** — Refactored to handle two event types: EventBridge (dispatch) and SQS (results). Dispatch: queries DB, claims nominations, runs skip checks, sends to SQS. Results: creates `OrganizationEvaluation` records or handles failures (retry/fail based on attempt count).
- **`configure_zappa.py`** — Added `dev-evaluator` and `prod-evaluator` stages with empty VPC config, Anthropic key, and results queue URL. Added requests queue URL to worker stages.

### Terraform
- 4 SQS queues: `evaluation-requests`, `evaluation-results`, and their DLQs (with redrive policies)
- 2 Lambda event source mappings (requests → evaluator, results → worker)
- SQS IAM permissions added to the zappa deployment policy

### CI/CD
- Added evaluator Lambda deploy step to `deploy.yml`
- Added `EVALUATION_REQUESTS_QUEUE_URL` and `EVALUATION_RESULTS_QUEUE_URL` env vars

### Tests
- 22 new tests: 14 for worker (routing, dispatch, results), 8 for evaluator
- All 369 tests pass

## Post-merge steps

1. Terraform apply (dev + prod) to create SQS queues and event source mappings
2. Set `EVALUATION_REQUESTS_QUEUE_URL` and `EVALUATION_RESULTS_QUEUE_URL` as GitHub environment variables for dev and prod
3. Deploy to create the evaluator Lambda functions
4. Verify end-to-end: admin queues nomination → worker dispatches → evaluator processes → worker writes result

## Test plan

- [x] All 369 tests pass
- [x] Ruff lint clean
- [x] Terraform validates
- [ ] Deploy to dev and verify evaluator Lambda created without VPC
- [ ] Queue a nomination and verify it flows through both Lambdas
- [ ] Verify failure handling: evaluator error → worker reverts to QUEUED or FAILED

🤖 Generated with [Claude Code](https://claude.com/claude-code)