### PR TITLE
docs(architecture): document worker/evaluator SQS pipeline

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,13 +113,14 @@ EventBridge (5 min)
     RDS (writes OrganizationEvaluation)
 ```
 
-- **Worker** (`nominations/worker.py`) — in VPC,
-  DB-facing. Handles two event types: EventBridge
+- **Worker** (`backend/terramedic/nominations/worker.py`) —
+  in VPC, DB-facing. Handles two event types: EventBridge
   (claim + skip-check queued nominations, enqueue to
   SQS) and SQS (persist results).
-- **Evaluator** (`nominations/evaluator.py`) — no VPC.
-  Fetches the org website, calls Anthropic, sends the
-  result back via the results queue.
+- **Evaluator**
+  (`backend/terramedic/nominations/evaluator.py`) — no
+  VPC. Fetches the org website, calls Anthropic, sends
+  the result back via the results queue.
 - **Queues**: `*-evaluation-requests` (DLQ after 2
   receives — Anthropic calls cost money) and
   `*-evaluation-results` (DLQ after 3 — DB-only

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,13 +33,13 @@ Tailwind CSS v4, Flowbite Svelte components.
 
 **Key paths:**
 
-| Path | Purpose |
-|---|---|
-| `terramedic/src/routes/` | Pages: home, about, volunteer, donate, resources, careers, other-actions, warming-stripes, contact-us, privacy |
-| `terramedic/src/lib/components/` | Reusable components (~24 files) |
-| `terramedic/src/lib/server/api.ts` | API client — fetches org data from the backend |
-| `terramedic/src/lib/utils/` | Client utilities (analytics, etc.) |
-| `terramedic/src/app.css` | Global styles, Tailwind v4 theme tokens |
+| Path                               | Purpose                                                                                                        |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `terramedic/src/routes/`           | Pages: home, about, volunteer, donate, resources, careers, other-actions, warming-stripes, contact-us, privacy |
+| `terramedic/src/lib/components/`   | Reusable components (~24 files)                                                                                |
+| `terramedic/src/lib/server/api.ts` | API client — fetches org data from the backend                                                                 |
+| `terramedic/src/lib/utils/`        | Client utilities (analytics, etc.)                                                                             |
+| `terramedic/src/app.css`           | Global styles, Tailwind v4 theme tokens                                                                        |
 
 **Data flow:** Each page that shows org data has a
 `+page.server.ts` load function that calls
@@ -59,13 +59,13 @@ django-parler (i18n), PostGIS (geospatial).
 
 **Key paths:**
 
-| Path | Purpose |
-|---|---|
-| `backend/terramedic/core/` | Settings, URL routing, API instance, secrets |
-| `backend/terramedic/organizations/` | Models, API endpoints, admin, fixtures |
-| `backend/terramedic/organizations/models.py` | Organization and Tag models |
-| `backend/terramedic/organizations/api.py` | REST endpoints |
-| `backend/terramedic/nominations/` | Nomination model + async evaluation pipeline (worker, evaluator) |
+| Path                                         | Purpose                                                          |
+| -------------------------------------------- | ---------------------------------------------------------------- |
+| `backend/terramedic/core/`                   | Settings, URL routing, API instance, secrets                     |
+| `backend/terramedic/organizations/`          | Models, API endpoints, admin, fixtures                           |
+| `backend/terramedic/organizations/models.py` | Organization and Tag models                                      |
+| `backend/terramedic/organizations/api.py`    | REST endpoints                                                   |
+| `backend/terramedic/nominations/`            | Nomination model + async evaluation pipeline (worker, evaluator) |
 
 **Models:**
 
@@ -79,12 +79,12 @@ django-parler (i18n), PostGIS (geospatial).
 
 **API endpoints** (all public, no auth):
 
-| Endpoint | Description |
-|---|---|
-| `GET /api/organizations/` | List orgs, optional `?category=` filter |
-| `GET /api/organizations/{id}/` | Single org |
-| `GET /api/organizations/nearby/` | GIS search by lat/lng/radius |
-| `GET /api/health` | Health check |
+| Endpoint                         | Description                             |
+| -------------------------------- | --------------------------------------- |
+| `GET /api/organizations/`        | List orgs, optional `?category=` filter |
+| `GET /api/organizations/{id}/`   | Single org                              |
+| `GET /api/organizations/nearby/` | GIS search by lat/lng/radius            |
+| `GET /api/health`                | Health check                            |
 
 **Data entry:** Orgs reach the public catalogue via Django
 admin. New candidates come from the nomination pipeline
@@ -105,8 +105,8 @@ EventBridge (5 min)
         ▼
   ┌──────────┐    evaluation-requests    ┌───────────┐
   │  worker  │──────── SQS ─────────────▶│ evaluator │
-  │  (VPC)   │                            │ (no VPC)  │
-  │          │◀──────── SQS ─────────────│           │
+  │  (VPC)   │                           │ (no VPC)  │
+  │          │◀─────── SQS ────-─────────│           │
   └────┬─────┘    evaluation-results     └───────────┘
        │
        ▼
@@ -160,15 +160,15 @@ environment.
 
 All workflows in `.github/workflows/`:
 
-| Workflow | Triggers | Purpose |
-|---|---|---|
-| `lint.yml` | Push, PRs | Prettier, ESLint, YAML lint, markdown lint, Ruff, mypy |
-| `test.yml` | Push, PRs | pytest (backend), Vitest + Playwright (frontend) |
-| `security.yml` | Push, PRs, weekly | CodeQL analysis |
-| `secret-scan.yml` | PRs to main | Gitleaks secret detection |
-| `secret-scan.yml` | Push, PRs | Gitleaks secret detection |
-| `deploy.yml` | Push to main/dev | Build Docker image, push to ECR, deploy via Zappa |
-| `dev_cost_control.yml` | Schedule | AWS dev environment cost monitoring |
+| Workflow               | Triggers          | Purpose                                                |
+| ---------------------- | ----------------- | ------------------------------------------------------ |
+| `lint.yml`             | Push, PRs         | Prettier, ESLint, YAML lint, markdown lint, Ruff, mypy |
+| `test.yml`             | Push, PRs         | pytest (backend), Vitest + Playwright (frontend)       |
+| `security.yml`         | Push, PRs, weekly | CodeQL analysis                                        |
+| `secret-scan.yml`      | PRs to main       | Gitleaks secret detection                              |
+| `secret-scan.yml`      | Push, PRs         | Gitleaks secret detection                              |
+| `deploy.yml`           | Push to main/dev  | Build Docker image, push to ECR, deploy via Zappa      |
+| `dev_cost_control.yml` | Schedule          | AWS dev environment cost monitoring                    |
 
 Deployment uses GitHub OIDC for AWS authentication — no
 long-lived credentials. Push to `main` deploys to prod;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,6 +65,7 @@ django-parler (i18n), PostGIS (geospatial).
 | `backend/terramedic/organizations/` | Models, API endpoints, admin, fixtures |
 | `backend/terramedic/organizations/models.py` | Organization and Tag models |
 | `backend/terramedic/organizations/api.py` | REST endpoints |
+| `backend/terramedic/nominations/` | Nomination model + async evaluation pipeline (worker, evaluator) |
 
 **Models:**
 
@@ -85,9 +86,49 @@ django-parler (i18n), PostGIS (geospatial).
 | `GET /api/organizations/nearby/` | GIS search by lat/lng/radius |
 | `GET /api/health` | Health check |
 
-**Data entry:** Via Django admin and the curation pipeline,
-which evaluates nominated organizations and saves approved
-entries through the admin or a future write API.
+**Data entry:** Orgs reach the public catalogue via Django
+admin. New candidates come from the nomination pipeline
+(next section), which writes `OrganizationEvaluation`
+records for curator review; approved orgs are then added
+through the admin or a future write API.
+
+## Nomination evaluation pipeline
+
+Two Lambdas connected by SQS. Splitting the original
+single worker eliminates the NAT Gateway (~$32/mo): the
+evaluator makes outbound HTTPS calls to Anthropic and
+target websites, which would otherwise need NAT from
+inside the VPC.
+
+```text
+EventBridge (5 min)
+        │
+        ▼
+  ┌──────────┐    evaluation-requests    ┌───────────┐
+  │  worker  │──────── SQS ─────────────▶│ evaluator │
+  │  (VPC)   │                            │ (no VPC)  │
+  │          │◀──────── SQS ─────────────│           │
+  └────┬─────┘    evaluation-results     └───────────┘
+       │
+       ▼
+    RDS (writes OrganizationEvaluation)
+```
+
+- **Worker** (`nominations/worker.py`) — in VPC,
+  DB-facing. Handles two event types: EventBridge
+  (claim + skip-check queued nominations, enqueue to
+  SQS) and SQS (persist results).
+- **Evaluator** (`nominations/evaluator.py`) — no VPC.
+  Fetches the org website, calls Anthropic, sends the
+  result back via the results queue.
+- **Queues**: `*-evaluation-requests` (DLQ after 2
+  receives — Anthropic calls cost money) and
+  `*-evaluation-results` (DLQ after 3 — DB-only
+  retries are cheap).
+- `EVALUATION_REQUESTS_QUEUE_URL` and
+  `EVALUATION_RESULTS_QUEUE_URL` are set as GitHub
+  environment variables (dev, prod) so Zappa injects
+  them at deploy time.
 
 ## Infrastructure
 
@@ -103,7 +144,8 @@ entries through the admin or a future write API.
 
 Provisions the AWS infrastructure across shared and prod
 accounts. Key modules: networking (VPC, subnets),
-database (RDS), lambda-ecr, zappa (S3 + IAM), secrets
+database (RDS), lambda-ecr, zappa (S3 + IAM + SQS +
+EventBridge for the evaluation pipeline), secrets
 (Secrets Manager), storage (S3 + CloudFront), github-oidc,
 monitoring (CloudWatch, budgets).
 
@@ -155,6 +197,10 @@ them fully before modifying.
   and router registration
 - `backend/terramedic/organizations/models.py` — Schema
   changes require migrations
+- `backend/terramedic/nominations/worker.py` — Evaluation
+  dispatcher + results persister (in VPC)
+- `backend/terramedic/nominations/evaluator.py` — Outbound
+  Anthropic + website fetch (outside VPC)
 - `backend/Dockerfile` — Lambda runtime image
 - `backend/entrypoint.sh` — Startup: migrations + seed
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -94,11 +94,10 @@ through the admin or a future write API.
 
 ## Nomination evaluation pipeline
 
-Two Lambdas connected by SQS. Splitting the original
-single worker eliminates the NAT Gateway (~$32/mo): the
-evaluator makes outbound HTTPS calls to Anthropic and
-target websites, which would otherwise need NAT from
-inside the VPC.
+Two Lambdas connected by SQS. The worker sits in the VPC
+to reach RDS; the evaluator sits outside the VPC so its
+outbound HTTPS calls (Anthropic + target websites) don't
+need a NAT Gateway (~$32/mo).
 
 ```text
 EventBridge (5 min)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,15 +161,16 @@ environment.
 
 All workflows in `.github/workflows/`:
 
-| Workflow               | Triggers          | Purpose                                                |
-| ---------------------- | ----------------- | ------------------------------------------------------ |
-| `lint.yml`             | Push, PRs         | Prettier, ESLint, YAML lint, markdown lint, Ruff, mypy |
-| `test.yml`             | Push, PRs         | pytest (backend), Vitest + Playwright (frontend)       |
-| `security.yml`         | Push, PRs, weekly | CodeQL analysis                                        |
-| `secret-scan.yml`      | PRs to main       | Gitleaks secret detection                              |
-| `secret-scan.yml`      | Push, PRs         | Gitleaks secret detection                              |
-| `deploy.yml`           | Push to main/dev  | Build Docker image, push to ECR, deploy via Zappa      |
-| `dev_cost_control.yml` | Schedule          | AWS dev environment cost monitoring                    |
+| Workflow                    | Triggers                | Purpose                                                |
+| --------------------------- | ----------------------- | ------------------------------------------------------ |
+| `lint.yml`                  | Push, PRs               | Prettier, ESLint, YAML lint, markdown lint, Ruff, mypy |
+| `test.yml`                  | Push, PRs               | pytest (backend), Vitest + Playwright (frontend)       |
+| `security.yml`              | Push, PRs, weekly       | CodeQL analysis                                        |
+| `secret-scan.yml`           | Push, PRs to main/dev   | Gitleaks secret detection                              |
+| `dependency-review.yml`     | PRs to main             | Dependency change risk review                          |
+| `dependabot-auto-merge.yml` | Dependabot PR events    | Auto-merge non-major Dependabot PRs                    |
+| `deploy.yml`                | Push to main/dev        | Build Docker image, push to ECR, deploy via Zappa     |
+| `dev_cost_control.yml`      | Schedule                | AWS dev environment cost monitoring                    |
 
 Deployment uses GitHub OIDC for AWS authentication — no
 long-lived credentials. Push to `main` deploys to prod;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,16 +161,16 @@ environment.
 
 All workflows in `.github/workflows/`:
 
-| Workflow                    | Triggers                | Purpose                                                |
-| --------------------------- | ----------------------- | ------------------------------------------------------ |
-| `lint.yml`                  | Push, PRs               | Prettier, ESLint, YAML lint, markdown lint, Ruff, mypy |
-| `test.yml`                  | Push, PRs               | pytest (backend), Vitest + Playwright (frontend)       |
-| `security.yml`              | Push, PRs, weekly       | CodeQL analysis                                        |
-| `secret-scan.yml`           | Push, PRs to main/dev   | Gitleaks secret detection                              |
-| `dependency-review.yml`     | PRs to main             | Dependency change risk review                          |
-| `dependabot-auto-merge.yml` | Dependabot PR events    | Auto-merge non-major Dependabot PRs                    |
-| `deploy.yml`                | Push to main/dev        | Build Docker image, push to ECR, deploy via Zappa     |
-| `dev_cost_control.yml`      | Schedule                | AWS dev environment cost monitoring                    |
+| Workflow                    | Triggers              | Purpose                                                |
+| --------------------------- | --------------------- | ------------------------------------------------------ |
+| `lint.yml`                  | Push, PRs             | Prettier, ESLint, YAML lint, markdown lint, Ruff, mypy |
+| `test.yml`                  | Push, PRs             | pytest (backend), Vitest + Playwright (frontend)       |
+| `security.yml`              | Push, PRs, weekly     | CodeQL analysis                                        |
+| `secret-scan.yml`           | Push, PRs to main/dev | Gitleaks secret detection                              |
+| `dependency-review.yml`     | PRs to main           | Dependency change risk review                          |
+| `dependabot-auto-merge.yml` | Dependabot PR events  | Auto-merge non-major Dependabot PRs                    |
+| `deploy.yml`                | Push to main/dev      | Build Docker image, push to ECR, deploy via Zappa      |
+| `dev_cost_control.yml`      | Schedule              | AWS dev environment cost monitoring                    |
 
 Deployment uses GitHub OIDC for AWS authentication — no
 long-lived credentials. Push to `main` deploys to prod;


### PR DESCRIPTION
## Summary

- Documents the async evaluation pipeline introduced by #205 in `docs/ARCHITECTURE.md`.
- Adds a new **Nomination evaluation pipeline** section with a diagram of the two-Lambda + SQS flow, the NAT-cost rationale, and the DLQ redrive policy.
- Updates the backend key-paths table, Terraform module list (SQS + EventBridge under zappa), and load-bearing files to include `worker.py` and `evaluator.py`.
- Mentions that `EVALUATION_REQUESTS_QUEUE_URL` / `EVALUATION_RESULTS_QUEUE_URL` live as GitHub environment variables (dev + prod already set post-merge).

## Test plan

- [ ] Render `docs/ARCHITECTURE.md` on GitHub — diagram + headings look right
- [ ] `markdownlint` passes in CI