### PR TITLE
fix(networking): add SQS VPC endpoint

### DIFF
--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -273,6 +273,7 @@ locals {
   interface_endpoints = {
     secretsmanager = "com.amazonaws.${var.aws_region}.secretsmanager"
     logs           = "com.amazonaws.${var.aws_region}.logs"
+    sqs            = "com.amazonaws.${var.aws_region}.sqs"
   }
   endpoint_subnet_ids = (
     length(local.private_subnet_ids) > 0 && var.enable_single_az_endpoints


### PR DESCRIPTION
## Summary

The worker Lambda from #205 sits in the VPC (needs RDS) and must reach SQS to dispatch evaluation requests. The VPC has no NAT Gateway (by design from #205) and had no SQS interface endpoint, so \`boto3.client(\"sqs\").send_message\` times out after 60s.

This PR adds \`sqs\` to the \`interface_endpoints\` map in the networking module, alongside the existing \`secretsmanager\` and \`logs\` endpoints.

## Cost

~\$7.20/mo per env (single-AZ, as configured). Still ~\$25/mo cheaper per env than reinstating a NAT Gateway.

## Evidence

Before (dev worker logs): \`ConnectTimeoutError: Connect timeout on endpoint URL: \"https://sqs.us-east-1.amazonaws.com/\"\`

Already applied to dev out-of-band to unblock the pipeline; verified the endpoint is \`available\` with private DNS enabled.

## Test plan

- [x] Applied to dev, endpoint status \`available\`
- [ ] Next worker EventBridge tick dispatches to SQS without timeout
- [ ] Merge, then \`terraform apply\` prod to pick up the same endpoint before evaluator pipeline goes live there