### PR TITLE
fix(evaluator): route SQS events to worker/evaluator handlers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           poetry run python scripts/configure_zappa.py
           poetry run zappa save-python-settings-file ${{ env.DEPLOY_ENV }}
+          poetry run python scripts/inject_event_mapping.py
 
       - name: Build and push Docker image
         working-directory: ./backend

--- a/backend/scripts/configure_zappa.py
+++ b/backend/scripts/configure_zappa.py
@@ -205,8 +205,9 @@ def configure_zappa_settings(
         # Queue URLs go into aws_environment_variables (→ Lambda's
         # Environment.Variables) so they're stage-specific. Putting
         # them in environment_variables would bake them into
-        # zappa_settings.py, which is generated for the `dev` stage
-        # only and shared across all 3 Lambdas — wrong target.
+        # zappa_settings.py, which is generated for the main deployed
+        # stage (`dev` or `prod`) and then shared by the worker and
+        # evaluator Lambdas/images — wrong target.
         # Worker: in VPC, has DB access, dispatches to requests queue
         settings[f"{env_key}-worker"] = {
             **lambda_base,

--- a/backend/scripts/configure_zappa.py
+++ b/backend/scripts/configure_zappa.py
@@ -202,22 +202,25 @@ def configure_zappa_settings(
             "ENVIRONMENT": env_cfg["env_name"],
             "DEBUG": "false",
         }
+        # Queue URLs go into aws_environment_variables (→ Lambda's
+        # Environment.Variables) so they're stage-specific. Putting
+        # them in environment_variables would bake them into
+        # zappa_settings.py, which is generated for the `dev` stage
+        # only and shared across all 3 Lambdas — wrong target.
         # Worker: in VPC, has DB access, dispatches to requests queue
         settings[f"{env_key}-worker"] = {
             **lambda_base,
             "extends": env_cfg["extends"],
             "stage": f"{env_key}-worker",
-            "environment_variables": {
-                **env_vars,
+            "environment_variables": env_vars,
+            "aws_environment_variables": {
+                "DATABASE_URL": db_secret_arn,
+                "SECRET_KEY": django_secret_arn,
                 **(
                     {"EVALUATION_REQUESTS_QUEUE_URL": eval_requests_queue_url}
                     if eval_requests_queue_url
                     else {}
                 ),
-            },
-            "aws_environment_variables": {
-                "DATABASE_URL": db_secret_arn,
-                "SECRET_KEY": django_secret_arn,
             },
         }
         # Evaluator: outside VPC, no DB, calls Anthropic API
@@ -229,16 +232,14 @@ def configure_zappa_settings(
                 "SubnetIds": [],
                 "SecurityGroupIds": [],
             },
-            "environment_variables": {
-                **env_vars,
+            "environment_variables": env_vars,
+            "aws_environment_variables": {
+                "SECRET_KEY": django_secret_arn,
                 **(
                     {"EVALUATION_RESULTS_QUEUE_URL": eval_results_queue_url}
                     if eval_results_queue_url
                     else {}
                 ),
-            },
-            "aws_environment_variables": {
-                "SECRET_KEY": django_secret_arn,
                 **(
                     {"ANTHROPIC_API_KEY": anthropic_secret_arn}
                     if anthropic_secret_arn

--- a/backend/scripts/inject_event_mapping.py
+++ b/backend/scripts/inject_event_mapping.py
@@ -86,20 +86,30 @@ def append_event_mapping(
 
 
 def require_mapping_in_ci(mapping: dict[str, str]) -> None:
-    """In CI, refuse to deploy without any SQS routing entries.
+    """In CI, refuse to deploy without both SQS routing entries.
 
-    Silently skipping would reproduce the exact runtime failure this
-    script is designed to prevent ("Cannot find a function to process
-    the triggered event") the next time an SQS event arrives.
+    The deploy workflow always brings up both the worker and the
+    evaluator, and each Lambda receives SQS events for its own queue.
+    A mapping that covers only one handler would leave the other
+    Lambda reproducing the exact runtime failure this script is
+    designed to prevent ("Cannot find a function to process the
+    triggered event").
     """
     if not os.environ.get("CI"):
         return
-    if mapping:
+    handlers = set(mapping.values())
+    missing_urls = []
+    if EVALUATOR_HANDLER not in handlers:
+        missing_urls.append("EVALUATION_REQUESTS_QUEUE_URL")
+    if WORKER_HANDLER not in handlers:
+        missing_urls.append("EVALUATION_RESULTS_QUEUE_URL")
+    if not missing_urls:
         return
     sys.stderr.write(
-        "Error: CI is set but neither EVALUATION_REQUESTS_QUEUE_URL "
-        "nor EVALUATION_RESULTS_QUEUE_URL is defined. The worker and "
-        "evaluator Lambdas would fail SQS routing at runtime.\n",
+        "Error: CI is set but the following queue URL(s) are not "
+        f"defined: {', '.join(missing_urls)}. Both are required; "
+        "missing one would leave the corresponding Lambda unable to "
+        "route its SQS events at runtime.\n",
     )
     sys.exit(1)
 

--- a/backend/scripts/inject_event_mapping.py
+++ b/backend/scripts/inject_event_mapping.py
@@ -62,8 +62,15 @@ def append_event_mapping(
     settings_path: Path,
     mapping: dict[str, str],
 ) -> None:
-    """Append an ``AWS_EVENT_MAPPING = {...}`` block to the file."""
+    """Append an ``AWS_EVENT_MAPPING = {...}`` block to the file.
+
+    Idempotent: returns early if the file already contains an
+    ``AWS_EVENT_MAPPING`` assignment, so re-runs don't accumulate
+    duplicate blocks.
+    """
     if not mapping:
+        return
+    if "AWS_EVENT_MAPPING" in settings_path.read_text():
         return
     lines = [
         "",

--- a/backend/scripts/inject_event_mapping.py
+++ b/backend/scripts/inject_event_mapping.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Append AWS_EVENT_MAPPING to the generated Zappa settings file.
+
+Zappa's handler routes non-API events (SQS, SNS, DynamoDB, Kinesis) by
+looking up the event source ARN in ``settings.AWS_EVENT_MAPPING``. That
+dict is only populated when a stage declares ``events`` in its Zappa
+config, which in turn makes Zappa manage the event source mapping —
+conflicting with Terraform, which owns the mapping for the nomination
+evaluation pipeline.
+
+This script sidesteps the conflict by populating ``AWS_EVENT_MAPPING``
+directly in the ``zappa_settings.py`` baked into the Docker image. The
+same image serves the API (``dev``), the worker (``dev-worker``), and
+the evaluator (``dev-evaluator``), so the mapping includes both queues
+and each Lambda routes the events it actually receives.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+EVALUATOR_HANDLER = (
+    "terramedic.nominations.evaluator.handle_evaluation_request"
+)
+WORKER_HANDLER = (
+    "terramedic.nominations.worker.process_evaluation_queue"
+)
+
+
+def sqs_url_to_arn(queue_url: str) -> str:
+    """Convert an SQS queue URL to its ARN.
+
+    URL: https://sqs.{region}.amazonaws.com/{account}/{queue-name}
+    ARN: arn:aws:sqs:{region}:{account}:{queue-name}
+    """
+    host_and_path = queue_url.split("://", 1)[-1]
+    host, account, name = host_and_path.split("/", 2)
+    region = host.split(".")[1]
+    return f"arn:aws:sqs:{region}:{account}:{name}"
+
+
+def build_event_mapping(
+    requests_queue_url: str,
+    results_queue_url: str,
+) -> dict[str, str]:
+    """Build AWS_EVENT_MAPPING from queue URLs.
+
+    Skips empty URLs so local builds without the pipeline configured
+    produce an empty mapping (and a no-op append).
+    """
+    mapping: dict[str, str] = {}
+    if requests_queue_url:
+        mapping[sqs_url_to_arn(requests_queue_url)] = EVALUATOR_HANDLER
+    if results_queue_url:
+        mapping[sqs_url_to_arn(results_queue_url)] = WORKER_HANDLER
+    return mapping
+
+
+def append_event_mapping(
+    settings_path: Path,
+    mapping: dict[str, str],
+) -> None:
+    """Append an ``AWS_EVENT_MAPPING = {...}`` block to the file."""
+    if not mapping:
+        return
+    lines = [
+        "",
+        "# Injected by scripts/inject_event_mapping.py for SQS routing.",
+        "AWS_EVENT_MAPPING = {",
+    ]
+    for arn, handler in mapping.items():
+        lines.append(f"    {arn!r}: {handler!r},")
+    lines.append("}")
+    lines.append("")
+    with settings_path.open("a") as f:
+        f.write("\n".join(lines))
+
+
+def main() -> None:
+    settings_path = (
+        Path(__file__).parent.parent / "zappa_settings.py"
+    )
+    if not settings_path.exists():
+        sys.stderr.write(
+            f"Error: {settings_path} not found. "
+            "Run `zappa save-python-settings-file` first.\n",
+        )
+        sys.exit(1)
+
+    mapping = build_event_mapping(
+        os.environ.get("EVALUATION_REQUESTS_QUEUE_URL", ""),
+        os.environ.get("EVALUATION_RESULTS_QUEUE_URL", ""),
+    )
+    append_event_mapping(settings_path, mapping)
+    if mapping:
+        sys.stdout.write(
+            f"Injected AWS_EVENT_MAPPING with {len(mapping)} entries "
+            f"into {settings_path}\n",
+        )
+    else:
+        sys.stdout.write(
+            "No queue URLs set; skipping AWS_EVENT_MAPPING injection.\n",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/inject_event_mapping.py
+++ b/backend/scripts/inject_event_mapping.py
@@ -78,6 +78,25 @@ def append_event_mapping(
         f.write("\n".join(lines))
 
 
+def require_mapping_in_ci(mapping: dict[str, str]) -> None:
+    """In CI, refuse to deploy without any SQS routing entries.
+
+    Silently skipping would reproduce the exact runtime failure this
+    script is designed to prevent ("Cannot find a function to process
+    the triggered event") the next time an SQS event arrives.
+    """
+    if not os.environ.get("CI"):
+        return
+    if mapping:
+        return
+    sys.stderr.write(
+        "Error: CI is set but neither EVALUATION_REQUESTS_QUEUE_URL "
+        "nor EVALUATION_RESULTS_QUEUE_URL is defined. The worker and "
+        "evaluator Lambdas would fail SQS routing at runtime.\n",
+    )
+    sys.exit(1)
+
+
 def main() -> None:
     settings_path = (
         Path(__file__).parent.parent / "zappa_settings.py"
@@ -93,6 +112,7 @@ def main() -> None:
         os.environ.get("EVALUATION_REQUESTS_QUEUE_URL", ""),
         os.environ.get("EVALUATION_RESULTS_QUEUE_URL", ""),
     )
+    require_mapping_in_ci(mapping)
     append_event_mapping(settings_path, mapping)
     if mapping:
         sys.stdout.write(

--- a/backend/scripts/tests/test_configure_zappa.py
+++ b/backend/scripts/tests/test_configure_zappa.py
@@ -218,3 +218,47 @@ class TestConfigureZappaSettings:
         settings = json.loads(output.read_text())
         assert settings["dev-worker"]["keep_warm"] is False
         assert settings["prod-worker"]["keep_warm"] is False
+
+    def test_worker_queue_url_in_aws_environment_variables(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # aws_environment_variables → Lambda's Environment.Variables
+        # (stage-specific). environment_variables bakes into a shared
+        # zappa_settings.py generated for `dev` only, so putting the
+        # queue URL there would leak dev's URL to dev-worker.
+        url = "https://sqs.us-east-1.amazonaws.com/1/requests"
+        monkeypatch.setenv("EVALUATION_REQUESTS_QUEUE_URL", url)
+        output = tmp_path / "zappa_settings.json"
+        configure_zappa_settings(output_path=output)
+
+        settings = json.loads(output.read_text())
+        worker = settings["dev-worker"]
+        assert worker["aws_environment_variables"][
+            "EVALUATION_REQUESTS_QUEUE_URL"
+        ] == url
+        assert (
+            "EVALUATION_REQUESTS_QUEUE_URL"
+            not in worker["environment_variables"]
+        )
+
+    def test_evaluator_queue_url_in_aws_environment_variables(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        url = "https://sqs.us-east-1.amazonaws.com/1/results"
+        monkeypatch.setenv("EVALUATION_RESULTS_QUEUE_URL", url)
+        output = tmp_path / "zappa_settings.json"
+        configure_zappa_settings(output_path=output)
+
+        settings = json.loads(output.read_text())
+        evaluator = settings["dev-evaluator"]
+        assert evaluator["aws_environment_variables"][
+            "EVALUATION_RESULTS_QUEUE_URL"
+        ] == url
+        assert (
+            "EVALUATION_RESULTS_QUEUE_URL"
+            not in evaluator["environment_variables"]
+        )

--- a/backend/scripts/tests/test_configure_zappa.py
+++ b/backend/scripts/tests/test_configure_zappa.py
@@ -225,9 +225,10 @@ class TestConfigureZappaSettings:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         # aws_environment_variables → Lambda's Environment.Variables
-        # (stage-specific). environment_variables bakes into a shared
-        # zappa_settings.py generated for `dev` only, so putting the
-        # queue URL there would leak dev's URL to dev-worker.
+        # (stage-specific). environment_variables bakes values into
+        # the settings file generated for the currently deployed
+        # stage, so putting the queue URL there could leak it across
+        # related stages such as dev/dev-worker or prod/prod-worker.
         url = "https://sqs.us-east-1.amazonaws.com/1/requests"
         monkeypatch.setenv("EVALUATION_REQUESTS_QUEUE_URL", url)
         output = tmp_path / "zappa_settings.json"

--- a/backend/scripts/tests/test_inject_event_mapping.py
+++ b/backend/scripts/tests/test_inject_event_mapping.py
@@ -2,11 +2,14 @@
 
 from pathlib import Path
 
+import pytest
+
 from scripts.inject_event_mapping import (
     EVALUATOR_HANDLER,
     WORKER_HANDLER,
     append_event_mapping,
     build_event_mapping,
+    require_mapping_in_ci,
     sqs_url_to_arn,
 )
 
@@ -95,3 +98,31 @@ class TestAppendEventMapping:
         append_event_mapping(settings, {})
 
         assert settings.read_text() == original
+
+
+class TestRequireMappingInCi:
+    def test_ci_with_nonempty_mapping_passes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("CI", "true")
+        require_mapping_in_ci({"arn:aws:sqs:us-east-1:1:q": "fn"})
+
+    def test_no_ci_with_empty_mapping_passes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("CI", raising=False)
+        require_mapping_in_ci({})
+
+    def test_ci_with_empty_mapping_exits_nonzero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("CI", "true")
+        with pytest.raises(SystemExit) as exc:
+            require_mapping_in_ci({})
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "EVALUATION_REQUESTS_QUEUE_URL" in err

--- a/backend/scripts/tests/test_inject_event_mapping.py
+++ b/backend/scripts/tests/test_inject_event_mapping.py
@@ -31,6 +31,13 @@ class TestSqsUrlToArn:
             == "arn:aws:sqs:eu-west-2:1:queue-name"
         )
 
+    def test_fifo_queue_url(self) -> None:
+        url = "https://sqs.us-east-1.amazonaws.com/1/my-queue.fifo"
+        assert (
+            sqs_url_to_arn(url)
+            == "arn:aws:sqs:us-east-1:1:my-queue.fifo"
+        )
+
 
 class TestBuildEventMapping:
     def test_both_queues(self) -> None:

--- a/backend/scripts/tests/test_inject_event_mapping.py
+++ b/backend/scripts/tests/test_inject_event_mapping.py
@@ -1,9 +1,11 @@
 """Tests for scripts/inject_event_mapping.py."""
 
+import importlib.util
 from pathlib import Path
 
 import pytest
 
+from scripts.configure_zappa import configure_zappa_settings
 from scripts.inject_event_mapping import (
     EVALUATOR_HANDLER,
     WORKER_HANDLER,
@@ -151,3 +153,66 @@ class TestRequireMappingInCi:
         assert exc.value.code == 1
         err = capsys.readouterr().err
         assert "EVALUATION_REQUESTS_QUEUE_URL" in err
+
+
+class TestPipelineIntegration:
+    """End-to-end: simulate the deploy pipeline and import the result.
+
+    Verifies that configure_zappa.py + (a stub of `zappa
+    save-python-settings-file`) + inject_event_mapping.py produce a
+    Python module that, when imported, exposes ``AWS_EVENT_MAPPING``
+    with the ARNs Zappa's handler will look up at runtime.
+    """
+
+    def test_produces_importable_settings_with_event_mapping(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setenv(
+            "DATABASE_SECRET_ARN",
+            "arn:aws:secretsmanager:us-east-1:1:secret:db",
+        )
+        monkeypatch.setenv(
+            "DJANGO_SECRET_ARN",
+            "arn:aws:secretsmanager:us-east-1:1:secret:key",
+        )
+        monkeypatch.setenv("ZAPPA_ROLE_NAME", "my-role")
+        requests_url = "https://sqs.us-east-1.amazonaws.com/1/req"
+        results_url = "https://sqs.us-east-1.amazonaws.com/1/res"
+        monkeypatch.setenv(
+            "EVALUATION_REQUESTS_QUEUE_URL", requests_url,
+        )
+        monkeypatch.setenv(
+            "EVALUATION_RESULTS_QUEUE_URL", results_url,
+        )
+
+        json_path = tmp_path / "zappa_settings.json"
+        configure_zappa_settings(output_path=json_path)
+        assert json_path.exists()
+
+        # Stub what `zappa save-python-settings-file` would produce.
+        # Zappa's own generator isn't invoked here — we just need a
+        # valid Python file for the inject step to append to.
+        settings_py = tmp_path / "zappa_settings.py"
+        settings_py.write_text(
+            "API_STAGE = 'dev'\nENVIRONMENT_VARIABLES = {}\n",
+        )
+
+        mapping = build_event_mapping(requests_url, results_url)
+        append_event_mapping(settings_py, mapping)
+
+        spec = importlib.util.spec_from_file_location(
+            "pipeline_test_zappa_settings", settings_py,
+        )
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        assert module.API_STAGE == "dev"
+        assert module.AWS_EVENT_MAPPING == {
+            "arn:aws:sqs:us-east-1:1:req": EVALUATOR_HANDLER,
+            "arn:aws:sqs:us-east-1:1:res": WORKER_HANDLER,
+        }

--- a/backend/scripts/tests/test_inject_event_mapping.py
+++ b/backend/scripts/tests/test_inject_event_mapping.py
@@ -1,0 +1,97 @@
+"""Tests for scripts/inject_event_mapping.py."""
+
+from pathlib import Path
+
+from scripts.inject_event_mapping import (
+    EVALUATOR_HANDLER,
+    WORKER_HANDLER,
+    append_event_mapping,
+    build_event_mapping,
+    sqs_url_to_arn,
+)
+
+
+class TestSqsUrlToArn:
+    def test_standard_url(self) -> None:
+        url = (
+            "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue"
+        )
+        assert (
+            sqs_url_to_arn(url)
+            == "arn:aws:sqs:us-east-1:123456789012:my-queue"
+        )
+
+    def test_different_region(self) -> None:
+        url = "https://sqs.eu-west-2.amazonaws.com/1/queue-name"
+        assert (
+            sqs_url_to_arn(url)
+            == "arn:aws:sqs:eu-west-2:1:queue-name"
+        )
+
+
+class TestBuildEventMapping:
+    def test_both_queues(self) -> None:
+        mapping = build_event_mapping(
+            "https://sqs.us-east-1.amazonaws.com/1/requests",
+            "https://sqs.us-east-1.amazonaws.com/1/results",
+        )
+        assert mapping == {
+            "arn:aws:sqs:us-east-1:1:requests": EVALUATOR_HANDLER,
+            "arn:aws:sqs:us-east-1:1:results": WORKER_HANDLER,
+        }
+
+    def test_empty_urls_yields_empty_mapping(self) -> None:
+        assert build_event_mapping("", "") == {}
+
+    def test_only_requests_queue(self) -> None:
+        mapping = build_event_mapping(
+            "https://sqs.us-east-1.amazonaws.com/1/requests",
+            "",
+        )
+        assert mapping == {
+            "arn:aws:sqs:us-east-1:1:requests": EVALUATOR_HANDLER,
+        }
+
+    def test_only_results_queue(self) -> None:
+        mapping = build_event_mapping(
+            "",
+            "https://sqs.us-east-1.amazonaws.com/1/results",
+        )
+        assert mapping == {
+            "arn:aws:sqs:us-east-1:1:results": WORKER_HANDLER,
+        }
+
+
+class TestAppendEventMapping:
+    def test_appends_valid_python_to_existing_file(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        settings = tmp_path / "zappa_settings.py"
+        settings.write_text(
+            "# existing content\nENVIRONMENT_VARIABLES = {}\n",
+        )
+        mapping = {
+            "arn:aws:sqs:us-east-1:1:foo": "module.func",
+        }
+
+        append_event_mapping(settings, mapping)
+
+        content = settings.read_text()
+        assert "ENVIRONMENT_VARIABLES = {}" in content
+        assert "AWS_EVENT_MAPPING" in content
+
+        # The appended block must be valid Python that defines the
+        # exact dict we expect.
+        namespace: dict[str, object] = {}
+        exec(content, namespace)  # noqa: S102
+        assert namespace["AWS_EVENT_MAPPING"] == mapping
+
+    def test_empty_mapping_is_noop(self, tmp_path: Path) -> None:
+        settings = tmp_path / "zappa_settings.py"
+        original = "SOME_SETTING = 1\n"
+        settings.write_text(original)
+
+        append_event_mapping(settings, {})
+
+        assert settings.read_text() == original

--- a/backend/scripts/tests/test_inject_event_mapping.py
+++ b/backend/scripts/tests/test_inject_event_mapping.py
@@ -99,6 +99,24 @@ class TestAppendEventMapping:
 
         assert settings.read_text() == original
 
+    def test_second_call_does_not_duplicate(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        settings = tmp_path / "zappa_settings.py"
+        settings.write_text("SOME_SETTING = 1\n")
+        mapping = {
+            "arn:aws:sqs:us-east-1:1:foo": "module.func",
+        }
+
+        append_event_mapping(settings, mapping)
+        after_first = settings.read_text()
+
+        append_event_mapping(settings, mapping)
+        after_second = settings.read_text()
+
+        assert after_first == after_second
+
 
 class TestRequireMappingInCi:
     def test_ci_with_nonempty_mapping_passes(

--- a/backend/scripts/tests/test_inject_event_mapping.py
+++ b/backend/scripts/tests/test_inject_event_mapping.py
@@ -128,12 +128,15 @@ class TestAppendEventMapping:
 
 
 class TestRequireMappingInCi:
-    def test_ci_with_nonempty_mapping_passes(
+    def test_ci_with_complete_mapping_passes(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("CI", "true")
-        require_mapping_in_ci({"arn:aws:sqs:us-east-1:1:q": "fn"})
+        require_mapping_in_ci({
+            "arn:aws:sqs:us-east-1:1:req": EVALUATOR_HANDLER,
+            "arn:aws:sqs:us-east-1:1:res": WORKER_HANDLER,
+        })
 
     def test_no_ci_with_empty_mapping_passes(
         self,
@@ -150,6 +153,35 @@ class TestRequireMappingInCi:
         monkeypatch.setenv("CI", "true")
         with pytest.raises(SystemExit) as exc:
             require_mapping_in_ci({})
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "EVALUATION_REQUESTS_QUEUE_URL" in err
+        assert "EVALUATION_RESULTS_QUEUE_URL" in err
+
+    def test_ci_with_only_requests_url_exits_nonzero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("CI", "true")
+        with pytest.raises(SystemExit) as exc:
+            require_mapping_in_ci({
+                "arn:aws:sqs:us-east-1:1:req": EVALUATOR_HANDLER,
+            })
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "EVALUATION_RESULTS_QUEUE_URL" in err
+
+    def test_ci_with_only_results_url_exits_nonzero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("CI", "true")
+        with pytest.raises(SystemExit) as exc:
+            require_mapping_in_ci({
+                "arn:aws:sqs:us-east-1:1:res": WORKER_HANDLER,
+            })
         assert exc.value.code == 1
         err = capsys.readouterr().err
         assert "EVALUATION_REQUESTS_QUEUE_URL" in err


### PR DESCRIPTION
## Summary

PR #205 wired SQS event source mappings in Terraform but the deployed Lambdas couldn't actually process the events. Live dev evaluator logs show:

```
[ERROR] handler Cannot find a function to process the triggered event.
```

This is Zappa's default handler failing because `zappa_settings.py` has no `AWS_EVENT_MAPPING` entry for the queue ARN. The same Docker image is shared across three Lambdas (`dev`, `dev-worker`, `dev-evaluator`) so adding Zappa `events` config would either require per-stage images or create/conflict with the Terraform-owned event source mappings.

## The fix

**1. `scripts/inject_event_mapping.py` (new)** — after `zappa save-python-settings-file`, appends an `AWS_EVENT_MAPPING` dict to `zappa_settings.py` mapping both SQS queue ARNs to the right functions:

```python
AWS_EVENT_MAPPING = {
    "arn:aws:sqs:...:terramedic-dev-evaluation-requests":
        "terramedic.nominations.evaluator.handle_evaluation_request",
    "arn:aws:sqs:...:terramedic-dev-evaluation-results":
        "terramedic.nominations.worker.process_evaluation_queue",
}
```

Zappa's handler reads `settings.AWS_EVENT_MAPPING.get(arn)` (`zappa/handler.py`) so populating it directly is enough. Each Lambda only receives events it's subscribed to, so the extra entries are harmless.

**2. `configure_zappa.py`** — moves `EVALUATION_REQUESTS_QUEUE_URL` / `EVALUATION_RESULTS_QUEUE_URL` from `environment_variables` to `aws_environment_variables`. Separate bug: `environment_variables` is baked into the shared `zappa_settings.py` generated for the `dev` stage only, so those URLs weren't reaching the worker/evaluator Lambdas. `aws_environment_variables` lands in Lambda's `Environment.Variables` per-stage at deploy time.

**3. `.github/workflows/deploy.yml`** — one new line to call `inject_event_mapping.py`.

## Tests

- 8 new tests in `test_inject_event_mapping.py` covering URL→ARN conversion, mapping construction (both queues / one / none), file append, and exec'ing the result to prove it's valid Python.
- 2 new tests in `test_configure_zappa.py` asserting the queue URLs land in `aws_environment_variables` (not `environment_variables`).
- All 42 script tests pass.

## Post-merge

After merging, redeploy dev (and later prod) via the `deploy.yml` workflow. The nomination currently stuck in `QUEUED` on dev should flow through end-to-end on the next EventBridge tick.

## Test plan

- [x] All existing tests pass
- [x] New tests cover both changes
- [ ] Deploy to dev, queue a nomination, verify evaluator log group shows `handle_evaluation_request` completing successfully
- [ ] Deploy to prod later (requires prod Terraform apply for SQS queues first)