### PR TITLE
fix(inject_event_mapping): check ARNs for idempotency

### DIFF
--- a/backend/scripts/inject_event_mapping.py
+++ b/backend/scripts/inject_event_mapping.py
@@ -64,13 +64,18 @@ def append_event_mapping(
 ) -> None:
     """Append an ``AWS_EVENT_MAPPING = {...}`` block to the file.
 
-    Idempotent: returns early if the file already contains an
-    ``AWS_EVENT_MAPPING`` assignment, so re-runs don't accumulate
-    duplicate blocks.
+    Idempotent: returns early if every ARN in ``mapping`` is already
+    present in the file. Checking for the string ``AWS_EVENT_MAPPING``
+    alone would give a false positive because
+    ``zappa save-python-settings-file`` emits an empty
+    ``AWS_EVENT_MAPPING={}`` assignment for every stage — we need to
+    append our populated one after it (later module-level assignments
+    win on import).
     """
     if not mapping:
         return
-    if "AWS_EVENT_MAPPING" in settings_path.read_text():
+    content = settings_path.read_text()
+    if all(arn in content for arn in mapping):
         return
     lines = [
         "",

--- a/backend/scripts/inject_event_mapping.py
+++ b/backend/scripts/inject_event_mapping.py
@@ -64,18 +64,21 @@ def append_event_mapping(
 ) -> None:
     """Append an ``AWS_EVENT_MAPPING = {...}`` block to the file.
 
-    Idempotent: returns early if every ARN in ``mapping`` is already
-    present in the file. Checking for the string ``AWS_EVENT_MAPPING``
-    alone would give a false positive because
-    ``zappa save-python-settings-file`` emits an empty
-    ``AWS_EVENT_MAPPING={}`` assignment for every stage — we need to
-    append our populated one after it (later module-level assignments
-    win on import).
+    Idempotent: returns early if every ``arn -> handler`` pair from
+    ``mapping`` is already present in the file. Matching on the pair
+    (rather than the ARN alone) correctly triggers a re-append when
+    a handler is renamed or the ARN appears in some unrelated
+    context. Later module-level assignments win on import, so our
+    populated block correctly overrides any earlier empty or stale
+    one that ``zappa save-python-settings-file`` may have emitted.
     """
     if not mapping:
         return
     content = settings_path.read_text()
-    if all(arn in content for arn in mapping):
+    if all(
+        f"{arn!r}: {handler!r}" in content
+        for arn, handler in mapping.items()
+    ):
         return
     lines = [
         "",

--- a/backend/scripts/tests/test_inject_event_mapping.py
+++ b/backend/scripts/tests/test_inject_event_mapping.py
@@ -126,6 +126,29 @@ class TestAppendEventMapping:
 
         assert after_first == after_second
 
+    def test_appends_despite_empty_aws_event_mapping_from_zappa(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # Regression: `zappa save-python-settings-file` emits an empty
+        # AWS_EVENT_MAPPING={} line. A naive substring-based idempotency
+        # guard would match it and skip the append, silently leaving
+        # the pipeline broken.
+        settings = tmp_path / "zappa_settings.py"
+        settings.write_text(
+            "API_STAGE='dev'\nAWS_EVENT_MAPPING={}\n",
+        )
+        mapping = {
+            "arn:aws:sqs:us-east-1:1:foo": "module.func",
+        }
+
+        append_event_mapping(settings, mapping)
+
+        content = settings.read_text()
+        namespace: dict[str, object] = {}
+        exec(content, namespace)  # noqa: S102
+        assert namespace["AWS_EVENT_MAPPING"] == mapping
+
 
 class TestRequireMappingInCi:
     def test_ci_with_complete_mapping_passes(

--- a/backend/scripts/tests/test_inject_event_mapping.py
+++ b/backend/scripts/tests/test_inject_event_mapping.py
@@ -149,6 +149,29 @@ class TestAppendEventMapping:
         exec(content, namespace)  # noqa: S102
         assert namespace["AWS_EVENT_MAPPING"] == mapping
 
+    def test_appends_when_handler_changed_for_existing_arn(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # If a handler is renamed, the file's existing block still
+        # contains the ARN — an ARN-only idempotency check would skip
+        # the append and leave the stale handler in place.
+        settings = tmp_path / "zappa_settings.py"
+        settings.write_text(
+            "AWS_EVENT_MAPPING = {\n"
+            "    'arn:aws:sqs:us-east-1:1:foo': 'old.handler',\n"
+            "}\n",
+        )
+        new_mapping = {
+            "arn:aws:sqs:us-east-1:1:foo": "new.handler",
+        }
+
+        append_event_mapping(settings, new_mapping)
+
+        namespace: dict[str, object] = {}
+        exec(settings.read_text(), namespace)  # noqa: S102
+        assert namespace["AWS_EVENT_MAPPING"] == new_mapping
+
 
 class TestRequireMappingInCi:
     def test_ci_with_complete_mapping_passes(


### PR DESCRIPTION
## Problem

The idempotency guard in `append_event_mapping` (added in #208) checked `"AWS_EVENT_MAPPING" in file.read_text()`. `zappa save-python-settings-file` already writes an empty `AWS_EVENT_MAPPING={}` line into the generated settings file, so the substring match always hit and the injection was silently skipped on every deploy. The `"Injected AWS_EVENT_MAPPING with 2 entries"` log was keyed off the in-memory mapping, not the actual file append.

Observed post-#208 merge: evaluator Lambda still fails with `Cannot find a function to process the triggered event` on SQS invocations.

## Fix

Check whether every ARN we want is already present in the file — i.e., "is the desired state already satisfied?" — rather than "does the file mention `AWS_EVENT_MAPPING` at all?". Later module-level assignments win on import, so our populated block correctly overrides Zappa's empty one.

## Tests

New test `test_appends_despite_empty_aws_event_mapping_from_zappa` seeds the file with Zappa's empty `AWS_EVENT_MAPPING={}` and asserts the injection still happens and produces the expected dict. 17 tests pass.

## Test plan

- [x] All 17 `test_inject_event_mapping.py` tests pass
- [ ] Deploy to dev; confirm `AWS_EVENT_MAPPING` in the deployed `zappa_settings.py` has both ARNs
- [ ] Confirm the stuck nomination flows through worker → SQS → evaluator → SQS → worker → DB