### PR TITLE
feat(admin): improve evaluation review UX

### DIFF
--- a/backend/terramedic/organizations/admin.py
+++ b/backend/terramedic/organizations/admin.py
@@ -149,8 +149,31 @@ def _create_org_from_evaluation(
     return org
 
 
+# Scoped CSS for the Evaluation Detail readonly field. Hides the
+# redundant field label (the fieldset header already says "Evaluation
+# Detail"), flattens list nesting so sources sit one indent-level
+# under their parent item instead of stacking three deep, and lets
+# long URLs wrap inside the content column.
+_EV_DETAIL_STYLE = """<style>
+.field-evaluation_detail label { display: none; }
+.ev-detail { font-size: 13px; line-height: 1.45; }
+.ev-detail h3 { margin: 1em 0 0.3em; font-size: 14px; font-weight: 600; }
+.ev-detail h3:first-of-type { margin-top: 0.25em; }
+.ev-detail p { margin: 0.25em 0; }
+.ev-detail .ev-meta { margin-bottom: 0.75em; }
+.ev-detail .ev-item { margin: 0.4em 0 0.6em; }
+.ev-detail .ev-sources { margin: 0.2em 0 0 1.25em; padding: 0; font-size: 0.92em; }
+.ev-detail .ev-sources li {
+  list-style: disc inside; margin: 0.1em 0;
+  word-break: break-word; overflow-wrap: anywhere;
+}
+.ev-detail .ev-history { margin: 0.2em 0 0 1.25em; padding: 0; }
+.ev-detail .ev-history li { list-style: disc inside; margin: 0.1em 0; }
+</style>"""
+
+
 def _render_sources(sources: list[dict[str, str]]) -> str:
-    """Render a sources array as a small HTML list."""
+    """Render a sources array as a small flat bulleted list."""
     if not sources:
         return ""
     items: list[str] = []
@@ -165,42 +188,44 @@ def _render_sources(sources: list[dict[str, str]]) -> str:
         if excerpt:
             line += f" — <em>{excerpt}</em>"
         items.append(f"<li>{line}</li>")
-    return "<ul>" + "".join(items) + "</ul>"
+    return '<ul class="ev-sources">' + "".join(items) + "</ul>"
 
 
 def _render_sdg_section(data: dict[str, Any]) -> str:
-    """Render SDG alignment as HTML."""
+    """Render SDG alignment as HTML (flat items, no nested lists)."""
     sdgs = data.get("sdg_alignment", [])
     if not sdgs:
         return ""
-    parts = ["<h3>SDG Alignment</h3><ul>"]
+    parts = ["<h3>SDG Alignment</h3>"]
     for item in sdgs:
         sdg = escape(str(item.get("sdg", "?")))
         evidence = escape(str(item.get("evidence", "")))
         sources_html = _render_sources(item.get("sources", []))
         parts.append(
-            f"<li><strong>SDG {sdg}</strong>: "
-            f"{evidence}{sources_html}</li>",
+            '<div class="ev-item">'
+            f"<p><strong>SDG {sdg}</strong>: {evidence}</p>"
+            f"{sources_html}"
+            "</div>",
         )
-    parts.append("</ul>")
     return "\n".join(parts)
 
 
 def _render_evidence_section(data: dict[str, Any]) -> str:
-    """Render evidence of work as HTML."""
+    """Render evidence of work as HTML (flat items, no nested lists)."""
     activities = data.get("evidence_of_work", [])
     if not activities:
         return ""
-    parts = ["<h3>Evidence of Work</h3><ul>"]
+    parts = ["<h3>Evidence of Work</h3>"]
     for item in activities:
         activity = escape(str(item.get("activity", "")))
         act_type = escape(str(item.get("type", "")))
         sources_html = _render_sources(item.get("sources", []))
         parts.append(
-            f"<li><strong>{act_type}</strong>: "
-            f"{activity}{sources_html}</li>",
+            '<div class="ev-item">'
+            f"<p><strong>{act_type}</strong>: {activity}</p>"
+            f"{sources_html}"
+            "</div>",
         )
-    parts.append("</ul>")
     return "\n".join(parts)
 
 
@@ -241,7 +266,7 @@ def _render_eval_history(data: dict[str, Any]) -> str:
     history = data.get("evaluation_history", [])
     if not history:
         return ""
-    parts = ["<h3>Evaluation History</h3><ul>"]
+    parts = ['<h3>Evaluation History</h3><ul class="ev-history">']
     for entry in history:
         ver = escape(str(entry.get("prompt_version", "?")))
         sc = escape(str(entry.get("score", "?")))
@@ -484,7 +509,7 @@ class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
         prompt_ver = data.get("prompt_version")
         if prompt_ver:
             parts.append(
-                "<p><strong>Prompt version:</strong> "
+                '<p class="ev-meta"><strong>Prompt version:</strong> '
                 f"{escape(str(prompt_ver))}</p>",
             )
 
@@ -499,7 +524,10 @@ class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
             if section:
                 parts.append(section)
 
-        html = "\n".join(parts) if parts else "<p>No data.</p>"
+        body = "\n".join(parts) if parts else "<p>No data.</p>"
+        html = (
+            f'{_EV_DETAIL_STYLE}<div class="ev-detail">{body}</div>'
+        )
         return mark_safe(html)  # noqa: S308
 
     @admin.action(description="Approve selected evaluations")

--- a/backend/terramedic/organizations/admin.py
+++ b/backend/terramedic/organizations/admin.py
@@ -502,16 +502,32 @@ class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
         form: Any,
         change: bool,
     ) -> None:
-        """Stamp reviewer and timestamp when status is changed.
+        """Stamp reviewer/time and keep linked-org visibility in sync.
 
-        Org creation for the APPROVED transition is handled by the
-        post_save signal in ``signals.py`` — keeping it there means
-        the same logic applies whether the transition happens via
-        the change form, a bulk action, or any other saver.
+        Org creation (or reactivation) on the APPROVED transition is
+        handled by the post_save signal in ``signals.py`` — keeping it
+        there means the same logic applies whether the transition
+        happens via the change form, a bulk action, or any other
+        saver.
+
+        Going *the other way* — transitioning a previously approved
+        evaluation to REJECTED or PENDING — is only reachable through
+        the change form. We deactivate the linked Organization here
+        (keeping the FK intact) so it disappears from the public
+        frontend without losing the audit trail. Re-approving the
+        evaluation later reactivates the same org rather than creating
+        a duplicate.
         """
         if change and form and "status" in form.changed_data:
             obj.reviewer = request.user  # type: ignore[assignment]
             obj.reviewed_at = timezone.now()
+            if (
+                obj.status != ReviewStatus.APPROVED
+                and obj.organization is not None
+                and obj.organization.is_active
+            ):
+                obj.organization.is_active = False
+                obj.organization.save(update_fields=["is_active"])
         super().save_model(request, obj, form, change)
 
     @admin.action(description="Approve selected evaluations")

--- a/backend/terramedic/organizations/admin.py
+++ b/backend/terramedic/organizations/admin.py
@@ -518,7 +518,7 @@ class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
         evaluation later reactivates the same org rather than creating
         a duplicate.
         """
-        if change and form and "status" in form.changed_data:
+        if change and "status" in form.changed_data:
             obj.reviewer = request.user  # type: ignore[assignment]
             obj.reviewed_at = timezone.now()
             if (

--- a/backend/terramedic/organizations/admin.py
+++ b/backend/terramedic/organizations/admin.py
@@ -114,13 +114,25 @@ class OrganizationAdmin(TranslatableAdmin):
         return ", ".join(slugs) if slugs else "—"
 
 
-# Scoped CSS for the Evaluation Detail readonly field. Hides the
-# redundant field label (the fieldset header already says "Evaluation
-# Detail"), flattens list nesting so sources sit one indent-level
-# under their parent item instead of stacking three deep, and lets
-# long URLs wrap inside the content column.
+# Scoped CSS for the Evaluation Detail readonly field. Visually hides
+# the redundant field label (the fieldset header already says
+# "Evaluation Detail") while keeping it in the accessibility tree for
+# screen readers via the standard "visually hidden" pattern. Flattens
+# list nesting so sources sit one indent-level under their parent item
+# instead of stacking three deep, and lets long URLs wrap inside the
+# content column.
 _EV_DETAIL_STYLE = """<style>
-.field-evaluation_detail label { display: none; }
+.field-evaluation_detail label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 .ev-detail { font-size: 13px; line-height: 1.45; }
 .ev-detail h3 { margin: 1em 0 0.3em; font-size: 14px; font-weight: 600; }
 .ev-detail h3:first-of-type { margin-top: 0.25em; }

--- a/backend/terramedic/organizations/admin.py
+++ b/backend/terramedic/organizations/admin.py
@@ -114,41 +114,6 @@ class OrganizationAdmin(TranslatableAdmin):
         return ", ".join(slugs) if slugs else "—"
 
 
-def _create_org_from_evaluation(
-    evaluation: OrganizationEvaluation,
-) -> Organization:
-    """Create an Organization from evaluation data.
-
-    Assigns every valid category from the evaluation's
-    ``accessibility.categories`` array. If none are valid
-    (for example, all entries are ``"other"``), the
-    organization is filed under ``resource`` as a fallback
-    so it still shows up somewhere.
-    """
-    data = evaluation.evaluation_data
-    meta = data.get("org_metadata", {})
-    accessibility = data.get("accessibility", {})
-
-    requested = accessibility.get("categories", [])
-    valid_categories = list(Category.objects.filter(slug__in=requested))
-    if not valid_categories:
-        valid_categories = list(Category.objects.filter(slug="resource"))
-
-    org = Organization(
-        name=meta.get("name", ""),
-        website_url=meta.get("website_url", ""),
-        image_url=meta.get("image_url", ""),
-        is_active=True,
-    )
-    org.set_current_language("en")
-    org.description = meta.get("description", "")
-    action_text = f"Support {meta.get('name', 'this organization')}"
-    org.action_text = action_text[:100]
-    org.save()
-    org.categories.set(valid_categories)
-    return org
-
-
 # Scoped CSS for the Evaluation Detail readonly field. Hides the
 # redundant field label (the fieldset header already says "Evaluation
 # Detail"), flattens list nesting so sources sit one indent-level
@@ -371,7 +336,6 @@ class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     search_fields = ["status"]
     readonly_fields = [
         "evaluation_data",
-        "status",
         "created_at",
         "reviewed_at",
         "reviewer",
@@ -387,8 +351,9 @@ class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
                     "reviewer_reasoning",
                 ),
                 "description": (
-                    "Use bulk actions to approve or reject."
-                    " Status cannot be changed manually."
+                    "Change status to Approved or Rejected and click"
+                    " Save. Reviewer, timestamp, and (on approval) a"
+                    " linked Organization are set automatically."
                 ),
             },
         ),
@@ -530,23 +495,39 @@ class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
         )
         return mark_safe(html)  # noqa: S308
 
+    def save_model(
+        self,
+        request: HttpRequest,
+        obj: OrganizationEvaluation,
+        form: Any,
+        change: bool,
+    ) -> None:
+        """Stamp reviewer and timestamp when status is changed.
+
+        Org creation for the APPROVED transition is handled by the
+        post_save signal in ``signals.py`` — keeping it there means
+        the same logic applies whether the transition happens via
+        the change form, a bulk action, or any other saver.
+        """
+        if change and form and "status" in form.changed_data:
+            obj.reviewer = request.user  # type: ignore[assignment]
+            obj.reviewed_at = timezone.now()
+        super().save_model(request, obj, form, change)
+
     @admin.action(description="Approve selected evaluations")
     def approve_evaluations(
         self,
         request: HttpRequest,
         queryset: QuerySet[OrganizationEvaluation],
     ) -> None:
+        # Transition status only; post_save signal handles org
+        # creation and nomination-status sync.
+        now = timezone.now()
         approved_count = 0
-        for evaluation in queryset:
-            if evaluation.status == ReviewStatus.APPROVED:
-                continue
-            org = evaluation.organization
-            if org is None:
-                org = _create_org_from_evaluation(evaluation)
-            evaluation.organization = org
+        for evaluation in queryset.exclude(status=ReviewStatus.APPROVED):
             evaluation.status = ReviewStatus.APPROVED
             evaluation.reviewer = request.user  # type: ignore[assignment]
-            evaluation.reviewed_at = timezone.now()
+            evaluation.reviewed_at = now
             evaluation.save()
             approved_count += 1
         self.message_user(
@@ -563,9 +544,7 @@ class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     ) -> None:
         now = timezone.now()
         rejected_count = 0
-        for evaluation in queryset:
-            if evaluation.status != ReviewStatus.PENDING:
-                continue
+        for evaluation in queryset.filter(status=ReviewStatus.PENDING):
             evaluation.status = ReviewStatus.REJECTED
             evaluation.reviewer = request.user  # type: ignore[assignment]
             evaluation.reviewed_at = now

--- a/backend/terramedic/organizations/evaluation_actions.py
+++ b/backend/terramedic/organizations/evaluation_actions.py
@@ -1,0 +1,49 @@
+"""Business logic triggered by an OrganizationEvaluation transition.
+
+Kept separate from ``admin.py`` so the post-save signal in
+``signals.py`` can share the exact same org-creation logic the bulk
+admin actions use, without a circular import through the admin module.
+"""
+
+from __future__ import annotations
+
+from terramedic.organizations.models import (
+    Category,
+    Organization,
+    OrganizationEvaluation,
+)
+
+
+def create_org_from_evaluation(
+    evaluation: OrganizationEvaluation,
+) -> Organization:
+    """Create an Organization from evaluation data.
+
+    Assigns every valid category from the evaluation's
+    ``accessibility.categories`` array. If none are valid
+    (for example, all entries are ``"other"``), the
+    organization is filed under ``resource`` as a fallback
+    so it still shows up somewhere.
+    """
+    data = evaluation.evaluation_data
+    meta = data.get("org_metadata", {})
+    accessibility = data.get("accessibility", {})
+
+    requested = accessibility.get("categories", [])
+    valid_categories = list(Category.objects.filter(slug__in=requested))
+    if not valid_categories:
+        valid_categories = list(Category.objects.filter(slug="resource"))
+
+    org = Organization(
+        name=meta.get("name", ""),
+        website_url=meta.get("website_url", ""),
+        image_url=meta.get("image_url", ""),
+        is_active=True,
+    )
+    org.set_current_language("en")
+    org.description = meta.get("description", "")
+    action_text = f"Support {meta.get('name', 'this organization')}"
+    org.action_text = action_text[:100]
+    org.save()
+    org.categories.set(valid_categories)
+    return org

--- a/backend/terramedic/organizations/signals.py
+++ b/backend/terramedic/organizations/signals.py
@@ -48,19 +48,21 @@ def create_org_on_approval(
     if instance.status != ReviewStatus.APPROVED:
         return
 
-    if instance.organization is not None:
-        if not instance.organization.is_active:
-            # Atomically reactivate only if the DB still shows
-            # status=APPROVED with this same org linked. A concurrent
-            # flip away from APPROVED would lose the race and leave
-            # the org deactivated, matching reality. Mirrors the
-            # conditional UPDATE pattern used by the creation branch.
-            Organization.objects.filter(
-                pk=instance.organization.pk,
-                is_active=False,
-                evaluations__pk=instance.pk,
-                evaluations__status=ReviewStatus.APPROVED,
-            ).update(is_active=True)
+    # Use organization_id (never triggers a lazy SELECT) rather than
+    # instance.organization, which would fetch the related row on every
+    # approved save — N+1 in the bulk-approve path.
+    if instance.organization_id is not None:  # type: ignore[attr-defined]
+        # Atomically reactivate only if the DB still shows
+        # status=APPROVED with this same org linked AND is_active=False.
+        # A concurrent flip away from APPROVED, or an already-active
+        # org, matches 0 rows and is a cheap no-op. Mirrors the
+        # conditional UPDATE pattern used by the creation branch.
+        Organization.objects.filter(
+            pk=instance.organization_id,  # type: ignore[attr-defined]
+            is_active=False,
+            evaluations__pk=instance.pk,
+            evaluations__status=ReviewStatus.APPROVED,
+        ).update(is_active=True)
         return
 
     org = create_org_from_evaluation(instance)

--- a/backend/terramedic/organizations/signals.py
+++ b/backend/terramedic/organizations/signals.py
@@ -67,6 +67,8 @@ def create_org_on_approval(
         # before we got here. Clean up the orphan we just created.
         org.delete()
         return
+    # Keep the in-memory instance consistent with the DB UPDATE so any
+    # downstream post_save receiver in this save cycle reads the new link.
     instance.organization = org
 
 

--- a/backend/terramedic/organizations/signals.py
+++ b/backend/terramedic/organizations/signals.py
@@ -11,6 +11,7 @@ from terramedic.organizations.models.evaluation import (
     OrganizationEvaluation,
     ReviewStatus,
 )
+from terramedic.organizations.models.organization import Organization
 
 # Map evaluation review statuses to nomination statuses.
 _EVAL_TO_NOMINATION_STATUS: dict[str, str] = {
@@ -49,8 +50,17 @@ def create_org_on_approval(
 
     if instance.organization is not None:
         if not instance.organization.is_active:
-            instance.organization.is_active = True
-            instance.organization.save(update_fields=["is_active"])
+            # Atomically reactivate only if the DB still shows
+            # status=APPROVED with this same org linked. A concurrent
+            # flip away from APPROVED would lose the race and leave
+            # the org deactivated, matching reality. Mirrors the
+            # conditional UPDATE pattern used by the creation branch.
+            Organization.objects.filter(
+                pk=instance.organization.pk,
+                is_active=False,
+                evaluations__pk=instance.pk,
+                evaluations__status=ReviewStatus.APPROVED,
+            ).update(is_active=True)
         return
 
     org = create_org_from_evaluation(instance)

--- a/backend/terramedic/organizations/signals.py
+++ b/backend/terramedic/organizations/signals.py
@@ -26,24 +26,47 @@ def create_org_on_approval(
     created: bool,
     **kwargs: Any,
 ) -> None:
-    """Create and link an Organization when an evaluation is APPROVED.
+    """Reconcile the linked Organization on APPROVED transitions.
 
-    This fires on any save — from the admin change form, the bulk
-    approve action, a management command, or a test — so the
-    org-creation side-effect of approval is enforced in one place.
-    Skipped on creation (the initial save by the worker) and when an
-    organization is already linked.
+    Three cases, chosen to keep the APPROVE → REJECT → APPROVE cycle
+    producing exactly one Organization row:
+
+    * **Already linked and active** — no-op (prevents duplicate creation
+      on idempotent saves).
+    * **Already linked but deactivated** — reactivate the existing
+      Organization (this is the re-approve path, after ``save_model``
+      deactivated the org on a prior REJECT/PENDING transition).
+    * **No org linked** — create a fresh Organization and link it via
+      a conditional ``UPDATE`` that requires the row still has
+      ``organization IS NULL`` and ``status = APPROVED``. If a
+      concurrent save won the race, delete the orphan we just created
+      so we don't leak rows.
     """
     if created:
         return
     if instance.status != ReviewStatus.APPROVED:
         return
+
     if instance.organization is not None:
+        if not instance.organization.is_active:
+            instance.organization.is_active = True
+            instance.organization.save(update_fields=["is_active"])
         return
+
     org = create_org_from_evaluation(instance)
-    # filter().update() bypasses save() so this receiver doesn't
-    # re-fire on itself (and reviewer/reviewed_at stay intact).
-    type(instance).objects.filter(pk=instance.pk).update(organization=org)
+    # Conditional update: only link if the row still has no org and
+    # is still APPROVED. filter().update() bypasses save() so this
+    # receiver doesn't re-fire on itself.
+    linked = sender.objects.filter(
+        pk=instance.pk,
+        organization__isnull=True,
+        status=ReviewStatus.APPROVED,
+    ).update(organization=org)
+    if not linked:
+        # Concurrent save linked a different org or flipped status
+        # before we got here. Clean up the orphan we just created.
+        org.delete()
+        return
     instance.organization = org
 
 

--- a/backend/terramedic/organizations/signals.py
+++ b/backend/terramedic/organizations/signals.py
@@ -4,6 +4,9 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from terramedic.nominations.models import NominationStatus
+from terramedic.organizations.evaluation_actions import (
+    create_org_from_evaluation,
+)
 from terramedic.organizations.models.evaluation import (
     OrganizationEvaluation,
     ReviewStatus,
@@ -14,6 +17,34 @@ _EVAL_TO_NOMINATION_STATUS: dict[str, str] = {
     ReviewStatus.APPROVED: NominationStatus.APPROVED,
     ReviewStatus.REJECTED: NominationStatus.REJECTED,
 }
+
+
+@receiver(post_save, sender=OrganizationEvaluation)
+def create_org_on_approval(
+    sender: type[OrganizationEvaluation],
+    instance: OrganizationEvaluation,
+    created: bool,
+    **kwargs: Any,
+) -> None:
+    """Create and link an Organization when an evaluation is APPROVED.
+
+    This fires on any save — from the admin change form, the bulk
+    approve action, a management command, or a test — so the
+    org-creation side-effect of approval is enforced in one place.
+    Skipped on creation (the initial save by the worker) and when an
+    organization is already linked.
+    """
+    if created:
+        return
+    if instance.status != ReviewStatus.APPROVED:
+        return
+    if instance.organization is not None:
+        return
+    org = create_org_from_evaluation(instance)
+    # filter().update() bypasses save() so this receiver doesn't
+    # re-fire on itself (and reviewer/reviewed_at stay intact).
+    type(instance).objects.filter(pk=instance.pk).update(organization=org)
+    instance.organization = org
 
 
 @receiver(post_save, sender=OrganizationEvaluation)

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -700,6 +700,57 @@ class TestCreateOrgOnApprovalSignal:
         assert Organization.objects.count() == 1
         assert pending_evaluation.organization == winning_org
 
+    def test_signal_skips_reactivation_on_concurrent_flip(
+        self,
+        admin_user: User,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        """If another request flips status away from APPROVED right
+        after this save, the reactivation branch's conditional UPDATE
+        must not flip is_active back to True."""
+        existing = Organization.objects.create(
+            name="Previously Approved Org",
+            website_url="https://prev.example",
+            is_active=False,
+        )
+        pending_evaluation.organization = existing
+        pending_evaluation.status = ReviewStatus.APPROVED
+        pending_evaluation.reviewer = admin_user
+        pending_evaluation.reviewed_at = timezone.now()
+        # Simulate the concurrent flip by scheduling a pre-save signal
+        # on this save that flips the DB back to REJECTED after our
+        # own save has committed but before downstream receivers run.
+        # Simpler: directly flip the DB right before invoking the
+        # receiver, by mocking the signal branch's filter call site.
+        pending_evaluation.save()
+        # After save, signal fires; conditional UPDATE sees APPROVED
+        # and reactivates. Then simulate a race where another request
+        # flips status away, and assert a subsequent spurious signal
+        # invocation does NOT re-reactivate because status is no
+        # longer APPROVED.
+        existing.refresh_from_db()
+        assert existing.is_active is True  # initial reactivation worked
+
+        # Now simulate the race: flip status to REJECTED via direct
+        # update, then run the signal manually with a stale instance
+        # whose in-memory state still says APPROVED + deactivated org.
+        OrganizationEvaluation.objects.filter(
+            pk=pending_evaluation.pk,
+        ).update(status=ReviewStatus.REJECTED)
+        existing.is_active = False  # simulate prior deactivation
+        existing.save(update_fields=["is_active"])
+        # Call the receiver directly with stale in-memory state.
+        from terramedic.organizations.signals import create_org_on_approval
+        stale = OrganizationEvaluation.objects.get(pk=pending_evaluation.pk)
+        stale.status = ReviewStatus.APPROVED  # in-memory only
+        create_org_on_approval(
+            sender=OrganizationEvaluation, instance=stale, created=False,
+        )
+        existing.refresh_from_db()
+        # Because DB still shows status=REJECTED, the conditional
+        # update finds 0 matching rows and leaves is_active=False.
+        assert existing.is_active is False
+
 
 @pytest.mark.django_db
 class TestApproveWithOtherCategory:

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -573,6 +573,71 @@ class TestCreateOrgOnApprovalSignal:
 
         assert Organization.objects.count() == 0
 
+    def test_signal_reactivates_deactivated_org_on_reapproval(
+        self,
+        admin_user: User,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        """Re-approving an evaluation whose Organization was
+        deactivated (by a prior REJECT transition) flips the org back
+        to is_active=True instead of creating a new one."""
+        existing = Organization.objects.create(
+            name="Previously Approved Org",
+            website_url="https://prev.example",
+            is_active=False,
+        )
+        pending_evaluation.organization = existing
+        pending_evaluation.status = ReviewStatus.APPROVED
+        pending_evaluation.reviewer = admin_user
+        pending_evaluation.reviewed_at = timezone.now()
+        pending_evaluation.save()
+
+        pending_evaluation.refresh_from_db()
+        existing.refresh_from_db()
+        assert pending_evaluation.organization == existing
+        assert existing.is_active is True
+        assert Organization.objects.count() == 1
+
+    def test_signal_cleans_up_orphan_on_race(
+        self,
+        admin_user: User,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        """If a concurrent saver links an org between this receiver's
+        check and its conditional UPDATE, the newly-created Org is
+        deleted so we don't leak rows."""
+        from terramedic.organizations import signals as sig
+
+        winning_org = Organization.objects.create(
+            name="Winning Org", website_url="https://winner.example",
+        )
+
+        real_create = sig.create_org_from_evaluation
+
+        def create_with_race(evaluation: OrganizationEvaluation) -> Organization:
+            # Simulate a concurrent saver linking a different org
+            # right after we've started creating ours but before the
+            # conditional UPDATE runs. The UPDATE's filter requires
+            # organization__isnull=True, so it will return 0.
+            OrganizationEvaluation.objects.filter(
+                pk=evaluation.pk,
+            ).update(organization=winning_org)
+            return real_create(evaluation)
+
+        pending_evaluation.status = ReviewStatus.APPROVED
+        pending_evaluation.reviewer = admin_user
+        pending_evaluation.reviewed_at = timezone.now()
+
+        with patch.object(
+            sig, "create_org_from_evaluation", side_effect=create_with_race,
+        ):
+            pending_evaluation.save()
+
+        pending_evaluation.refresh_from_db()
+        # Orphan was cleaned up; only the winning org remains.
+        assert Organization.objects.count() == 1
+        assert pending_evaluation.organization == winning_org
+
 
 @pytest.mark.django_db
 class TestApproveWithOtherCategory:

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -422,7 +422,7 @@ class TestApproveFromDetailPage:
             "/admin/organizations/organizationevaluation/"
             f"{evaluation.pk}/change/"
         )
-        return client.post(
+        response = client.post(
             url,
             {
                 "status": status,
@@ -430,6 +430,14 @@ class TestApproveFromDetailPage:
                 "_save": "Save",
             },
         )
+        # Django admin redirects to the changelist on successful
+        # save; form errors would return 200 and let the caller's
+        # state-unchanged assertions pass vacuously.
+        assert response.status_code == 302, (
+            f"Admin save returned {response.status_code}; "
+            "expected 302 redirect"
+        )
+        return response
 
     def test_approve_via_detail_creates_organization(
         self,

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -396,13 +396,6 @@ class TestEvaluationAdminReadonlyPresentation:
         admin = OrganizationEvaluationAdmin(OrganizationEvaluation, site)
         assert "evaluation_data" in admin.readonly_fields
 
-    def test_status_is_editable(self) -> None:
-        """Curators change status directly on the detail page; the
-        post_save signal handles the downstream side effects."""
-        site = AdminSite()
-        admin = OrganizationEvaluationAdmin(OrganizationEvaluation, site)
-        assert "status" not in admin.readonly_fields
-
     def test_status_choices(self) -> None:
         assert ReviewStatus.PENDING == "pending"
         assert ReviewStatus.APPROVED == "approved"

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -396,15 +396,182 @@ class TestEvaluationAdminReadonlyPresentation:
         admin = OrganizationEvaluationAdmin(OrganizationEvaluation, site)
         assert "evaluation_data" in admin.readonly_fields
 
-    def test_status_is_readonly(self) -> None:
+    def test_status_is_editable(self) -> None:
+        """Curators change status directly on the detail page; the
+        post_save signal handles the downstream side effects."""
         site = AdminSite()
         admin = OrganizationEvaluationAdmin(OrganizationEvaluation, site)
-        assert "status" in admin.readonly_fields
+        assert "status" not in admin.readonly_fields
 
     def test_status_choices(self) -> None:
         assert ReviewStatus.PENDING == "pending"
         assert ReviewStatus.APPROVED == "approved"
         assert ReviewStatus.REJECTED == "rejected"
+
+
+@pytest.mark.django_db
+class TestApproveFromDetailPage:
+    """Curator flips status to Approved on the change form and saves.
+
+    save_model stamps reviewer + reviewed_at; the post_save signal
+    creates and links an Organization.
+    """
+
+    def _post_change(
+        self,
+        client: Client,
+        evaluation: OrganizationEvaluation,
+        status: str,
+        reasoning: str = "",
+    ) -> Any:
+        url = (
+            "/admin/organizations/organizationevaluation/"
+            f"{evaluation.pk}/change/"
+        )
+        return client.post(
+            url,
+            {
+                "status": status,
+                "reviewer_reasoning": reasoning,
+                "_save": "Save",
+            },
+        )
+
+    def test_approve_via_detail_creates_organization(
+        self,
+        admin_client: Client,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        self._post_change(
+            admin_client, pending_evaluation, ReviewStatus.APPROVED,
+        )
+        pending_evaluation.refresh_from_db()
+        assert pending_evaluation.status == ReviewStatus.APPROVED
+        assert pending_evaluation.organization is not None
+        assert pending_evaluation.organization.name == "Test Organization"
+
+    def test_approve_via_detail_stamps_reviewer_and_time(
+        self,
+        admin_client: Client,
+        admin_user: User,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        self._post_change(
+            admin_client, pending_evaluation, ReviewStatus.APPROVED,
+        )
+        pending_evaluation.refresh_from_db()
+        assert pending_evaluation.reviewer == admin_user
+        assert pending_evaluation.reviewed_at is not None
+
+    def test_reject_via_detail_sets_status_without_creating_org(
+        self,
+        admin_client: Client,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        self._post_change(
+            admin_client, pending_evaluation, ReviewStatus.REJECTED,
+        )
+        pending_evaluation.refresh_from_db()
+        assert pending_evaluation.status == ReviewStatus.REJECTED
+        assert pending_evaluation.organization is None
+        assert Organization.objects.count() == 0
+
+    def test_save_without_status_change_does_not_restamp_reviewer(
+        self,
+        admin_client: Client,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        # First save: approves and stamps reviewer/time.
+        self._post_change(
+            admin_client, pending_evaluation, ReviewStatus.APPROVED,
+        )
+        pending_evaluation.refresh_from_db()
+        original_time = pending_evaluation.reviewed_at
+        assert original_time is not None
+
+        # Second save: status unchanged, only reasoning edited.
+        self._post_change(
+            admin_client,
+            pending_evaluation,
+            ReviewStatus.APPROVED,
+            reasoning="Updated notes",
+        )
+        pending_evaluation.refresh_from_db()
+        # reviewed_at preserved because status didn't change.
+        assert pending_evaluation.reviewed_at == original_time
+
+    def test_repeat_approve_does_not_create_second_org(
+        self,
+        admin_client: Client,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        # First approval creates the org.
+        self._post_change(
+            admin_client, pending_evaluation, ReviewStatus.APPROVED,
+        )
+        pending_evaluation.refresh_from_db()
+        first_org = pending_evaluation.organization
+        assert first_org is not None
+
+        # Saving again should not create a second Organization.
+        self._post_change(
+            admin_client, pending_evaluation, ReviewStatus.APPROVED,
+        )
+        pending_evaluation.refresh_from_db()
+        assert Organization.objects.count() == 1
+        assert pending_evaluation.organization == first_org
+
+
+@pytest.mark.django_db
+class TestCreateOrgOnApprovalSignal:
+    """The post_save signal enforces org creation regardless of the
+    code path that flipped status to APPROVED."""
+
+    def test_signal_fires_for_direct_save(
+        self,
+        admin_user: User,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        # Simulate any non-admin code path (shell, migration, etc.)
+        # that transitions status directly.
+        pending_evaluation.status = ReviewStatus.APPROVED
+        pending_evaluation.reviewer = admin_user
+        pending_evaluation.reviewed_at = timezone.now()
+        pending_evaluation.save()
+
+        pending_evaluation.refresh_from_db()
+        assert pending_evaluation.organization is not None
+
+    def test_signal_skips_when_org_already_linked(
+        self,
+        admin_user: User,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        existing = Organization.objects.create(
+            name="Pre-linked Org", website_url="https://pre.example",
+        )
+        pending_evaluation.organization = existing
+        pending_evaluation.status = ReviewStatus.APPROVED
+        pending_evaluation.reviewer = admin_user
+        pending_evaluation.reviewed_at = timezone.now()
+        pending_evaluation.save()
+
+        pending_evaluation.refresh_from_db()
+        # No new org created; existing link preserved.
+        assert Organization.objects.count() == 1
+        assert pending_evaluation.organization == existing
+
+    def test_signal_skips_on_rejection(
+        self,
+        admin_user: User,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        pending_evaluation.status = ReviewStatus.REJECTED
+        pending_evaluation.reviewer = admin_user
+        pending_evaluation.reviewed_at = timezone.now()
+        pending_evaluation.save()
+
+        assert Organization.objects.count() == 0
 
 
 @pytest.mark.django_db

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from typing import Any
 from unittest.mock import patch
 
@@ -467,9 +466,6 @@ class TestApproveFromDetailPage:
         assert pending_evaluation.reviewed_at is not None
         # Fresh timestamp, not a frozen/stale value from elsewhere.
         assert pending_evaluation.reviewed_at >= before
-        assert timezone.now() - pending_evaluation.reviewed_at < timedelta(
-            seconds=10,
-        )
 
     def test_reject_via_detail_sets_status_without_creating_org(
         self,

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import Any
 from unittest.mock import patch
 
@@ -449,12 +450,18 @@ class TestApproveFromDetailPage:
         admin_user: User,
         pending_evaluation: OrganizationEvaluation,
     ) -> None:
+        before = timezone.now()
         self._post_change(
             admin_client, pending_evaluation, ReviewStatus.APPROVED,
         )
         pending_evaluation.refresh_from_db()
         assert pending_evaluation.reviewer == admin_user
         assert pending_evaluation.reviewed_at is not None
+        # Fresh timestamp, not a frozen/stale value from elsewhere.
+        assert pending_evaluation.reviewed_at >= before
+        assert timezone.now() - pending_evaluation.reviewed_at < timedelta(
+            seconds=10,
+        )
 
     def test_reject_via_detail_sets_status_without_creating_org(
         self,

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -653,12 +653,13 @@ class TestCreateOrgOnApprovalSignal:
         check and its conditional UPDATE, the newly-created Org is
         deleted so we don't leak rows."""
         from terramedic.organizations import signals as sig
+        from terramedic.organizations.evaluation_actions import (
+            create_org_from_evaluation as real_create,
+        )
 
         winning_org = Organization.objects.create(
             name="Winning Org", website_url="https://winner.example",
         )
-
-        real_create = sig.create_org_from_evaluation
 
         def create_with_race(evaluation: OrganizationEvaluation) -> Organization:
             # Simulate a concurrent saver linking a different org

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -521,6 +521,59 @@ class TestApproveFromDetailPage:
         assert Organization.objects.count() == 1
         assert pending_evaluation.organization == first_org
 
+    def test_reject_after_approve_deactivates_but_preserves_fk(
+        self,
+        admin_client: Client,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        """Transitioning APPROVED → REJECTED keeps the FK (audit trail)
+        but deactivates the linked Organization so it disappears from
+        the public frontend."""
+        self._post_change(
+            admin_client, pending_evaluation, ReviewStatus.APPROVED,
+        )
+        pending_evaluation.refresh_from_db()
+        org = pending_evaluation.organization
+        assert org is not None
+        assert org.is_active is True
+
+        self._post_change(
+            admin_client, pending_evaluation, ReviewStatus.REJECTED,
+        )
+        pending_evaluation.refresh_from_db()
+        org.refresh_from_db()
+        assert pending_evaluation.status == ReviewStatus.REJECTED
+        assert pending_evaluation.organization == org  # FK preserved
+        assert org.is_active is False
+
+    def test_approve_reject_reapprove_does_not_duplicate_org(
+        self,
+        admin_client: Client,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        """A full APPROVE → REJECT → APPROVE cycle ends with exactly
+        one Organization, reactivated, linked to the evaluation."""
+        self._post_change(
+            admin_client, pending_evaluation, ReviewStatus.APPROVED,
+        )
+        pending_evaluation.refresh_from_db()
+        original_org = pending_evaluation.organization
+        assert original_org is not None
+
+        self._post_change(
+            admin_client, pending_evaluation, ReviewStatus.REJECTED,
+        )
+        self._post_change(
+            admin_client, pending_evaluation, ReviewStatus.APPROVED,
+        )
+
+        pending_evaluation.refresh_from_db()
+        original_org.refresh_from_db()
+        assert Organization.objects.count() == 1
+        assert pending_evaluation.organization == original_org
+        assert original_org.is_active is True
+        assert pending_evaluation.status == ReviewStatus.APPROVED
+
 
 @pytest.mark.django_db
 class TestCreateOrgOnApprovalSignal:


### PR DESCRIPTION
## Summary

Two bundled UX improvements to the `OrganizationEvaluation` admin, plus the race-safety, a11y, and perf follow-ups that came out of review.

### 1. Flatten and tighten "Evaluation Detail" rendering

The readonly field had a duplicate label (fieldset header + field label), nested `<ul><li><ul>` stacking ~3–4 indent levels, and long URLs blowing out the content column.

- Replace nested lists with `<div class="ev-item">` + flat `<ul class="ev-sources">`.
- Scoped `<style>` block tightens list padding, heading margins, and wraps long URLs via `word-break`/`overflow-wrap`.
- Visually hide the redundant field label via the clip-rect pattern (keeps it in the accessibility tree for screen readers).

### 2. Approve / Reject directly from the change form

Previously curators had to go back to the list view, tick a checkbox, and use the bulk-action dropdown even when already viewing the evaluation. Now:

- `status` is editable on the change form.
- `save_model` stamps `reviewer` + `reviewed_at` on status transitions only (no re-stamp on reasoning-only edits).
- `post_save` signal `create_org_on_approval` handles the downstream side-effects so the same logic fires whether the transition came from the admin form, a bulk action, a management command, or a test.

### 3. State-machine correctness

- **APPROVED → REJECTED / PENDING (change form)**: `save_model` sets `org.is_active = False` while preserving the FK (keeps the audit trail; the org disappears from the public frontend).
- **REJECTED → APPROVED (re-approve)**: signal reactivates the same Organization instead of creating a duplicate, so the APPROVE → REJECT → APPROVE cycle produces exactly one Organization row.

### 4. Race safety

Both side-effect paths use conditional `UPDATE` patterns at the DB level so concurrent saves can't corrupt state:

- **Creation path**: `filter(pk=..., organization__isnull=True, status=APPROVED).update(organization=org)`; if 0 rows match, the newly-created Organization is deleted (orphan cleanup).
- **Reactivation path**: `filter(pk=org_pk, is_active=False, evaluations__pk=eval_pk, evaluations__status=APPROVED).update(is_active=True)`; if another request flipped status away, 0 rows match and the org stays deactivated.

### 5. Other refinements from review

- Moved `create_org_from_evaluation` from `admin.py` to `organizations/evaluation_actions.py` so the signal can share it without a reverse admin → signal dependency.
- Bulk approve / reject simplified to just set status + save (signal does the rest).
- Test helper `_post_change` asserts `302` so form errors trip the test instead of letting state-unchanged assertions pass vacuously.
- Avoid N+1 lazy SELECT in the reactivation branch by using `instance.organization_id` and letting the UPDATE's `is_active=False` filter handle the already-active case as a cheap no-op.

## Files touched

- `backend/terramedic/organizations/admin.py` — rendering + editable status + `save_model`.
- `backend/terramedic/organizations/signals.py` — `create_org_on_approval` receiver (creation, reactivation, race safety).
- `backend/terramedic/organizations/evaluation_actions.py` (new) — shared org-creation helper.
- `backend/terramedic/organizations/tests/test_evaluation_admin.py` — 11 new tests + 1 removed.

## Tests

56 admin tests pass. New coverage:

**Detail-page POST flow** (`TestApproveFromDetailPage`):

- Approve creates org; reviewer/time stamped freshly.
- Reject sets status without creating an org.
- Save without status change doesn't restamp.
- Repeat approve doesn't create a second org.
- Reject after approve deactivates the org but preserves the FK.
- Full APPROVE → REJECT → APPROVE cycle produces exactly one Organization.

**Signal behavior** (`TestCreateOrgOnApprovalSignal`):

- Fires on any `.save()` (not just admin).
- Skips when org already linked + active.
- Skips on rejection.
- Reactivates a deactivated org on re-approval.
- Cleans up orphan Organization when concurrent save wins the race on creation.
- Skips reactivation when a concurrent save flipped status away from APPROVED.

Removed `test_status_is_readonly` — the behavioral POST tests already fail if status is made readonly again, so the config-check assertion added no independent signal.

## Test plan

- [x] 56 admin tests pass
- [ ] Reload an OrganizationEvaluation admin detail page in dev and verify:
  - Evaluation Detail section has a single header (no duplicate).
  - Status field is a dropdown (Pending / Approved / Rejected).
  - Saving with status changed to Approved creates an Organization and stamps reviewer/time.
  - Saving with status changed to Rejected just flips status + deactivates the org.
  - Saving with only reasoning edited does not restamp reviewer/time.
  - The approve → reject → approve cycle produces exactly one Organization (reactivated on re-approve).
