### PR TITLE
feat(nominations): add evaluate_pending local command (Max billing)

### DIFF
--- a/backend/curation/evaluate.py
+++ b/backend/curation/evaluate.py
@@ -469,35 +469,16 @@ def evaluate_org(
     return result
 
 
-def evaluate_org_via_claude_code(
-    url: str,
-    model: str = "sonnet",
-    categories: list[str] | None = None,
-    timeout: int = _CLAUDE_CLI_TIMEOUT,
-) -> dict[str, Any]:
-    """Evaluate an organization by shelling out to the ``claude`` CLI.
+def _invoke_claude_cli(
+    cmd: list[str], timeout: int, url: str,
+) -> str:
+    """Run the ``claude`` CLI and return the model's text response.
 
-    Uses the caller's Claude Code session, so billing hits the Max
-    subscription rather than the per-token Anthropic API. Requires the
-    shell to be logged into Claude Code (``claude auth``). Not usable
-    from Lambda — Claude Code has no service-account mode.
-
-    Returns a schema-validated evaluation dict, just like ``evaluate_org``.
-    ``evaluated_by`` is stamped with a ``claude-code:`` prefix so the two
-    paths are distinguishable in stored records.
+    Handles exit code, JSON envelope parsing, ``is_error`` handling,
+    and per-call usage logging. Raises ``RuntimeError`` on non-zero
+    exit or ``is_error: true``; ``ValueError`` on malformed stdout or
+    missing ``result`` field.
     """
-    _validate_url(url)
-    user_content = _build_user_message(url, categories=categories)
-
-    cmd = [
-        "claude",
-        "-p", user_content,
-        "--append-system-prompt", SYSTEM_PROMPT,
-        "--tools", "WebSearch,WebFetch",
-        "--output-format", "json",
-        "--permission-mode", "dontAsk",
-        "--model", model,
-    ]
     proc = subprocess.run(
         cmd,
         capture_output=True,
@@ -539,10 +520,42 @@ def evaluate_org_via_claude_code(
         tool_use.get("web_search_requests"),
         tool_use.get("web_fetch_requests"),
     )
+    return text
+
+
+def evaluate_org_via_claude_code(
+    url: str,
+    model: str = "sonnet",
+    categories: list[str] | None = None,
+    timeout: int = _CLAUDE_CLI_TIMEOUT,
+) -> dict[str, Any]:
+    """Evaluate an organization by shelling out to the ``claude`` CLI.
+
+    Uses the caller's Claude Code session, so billing hits the Max
+    subscription rather than the per-token Anthropic API. Requires the
+    shell to be logged into Claude Code (``claude auth``). Not usable
+    from Lambda — Claude Code has no service-account mode.
+
+    Returns a schema-validated evaluation dict, just like ``evaluate_org``.
+    ``evaluated_by`` is stamped with a ``claude-code:`` prefix so the two
+    paths are distinguishable in stored records.
+    """
+    _validate_url(url)
+    user_content = _build_user_message(url, categories=categories)
+
+    cmd = [
+        "claude",
+        "-p", user_content,
+        "--append-system-prompt", SYSTEM_PROMPT,
+        "--tools", "WebSearch,WebFetch",
+        "--output-format", "json",
+        "--permission-mode", "dontAsk",
+        "--model", model,
+    ]
+    text = _invoke_claude_cli(cmd, timeout=timeout, url=url)
 
     data = _extract_json(text)
     _clean_response(data)
-
     data["evaluated_at"] = (
         datetime.datetime.now(datetime.UTC).isoformat()
     )
@@ -550,7 +563,6 @@ def evaluate_org_via_claude_code(
     data["prompt_version"] = PROMPT_VERSION
 
     _validate_against_schema(data, source="Claude Code output")
-
     return data
 
 

--- a/backend/curation/evaluate.py
+++ b/backend/curation/evaluate.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 import argparse
 import datetime
 import json
+import logging
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -22,9 +24,12 @@ from urllib.parse import urlparse
 
 from curation.prompt import PROMPT_VERSION, SYSTEM_PROMPT
 
+logger = logging.getLogger(__name__)
+
 _SCHEMA_PATH = Path(__file__).parent / "schema.json"
 _MAX_PAGE_CHARS = 12000
 _FETCH_TIMEOUT = 15
+_CLAUDE_CLI_TIMEOUT = 600
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -452,6 +457,110 @@ def evaluate_org(
         raise ValueError(msg) from exc
 
     return result
+
+
+def evaluate_org_via_claude_code(
+    url: str,
+    model: str = "sonnet",
+    categories: list[str] | None = None,
+    timeout: int = _CLAUDE_CLI_TIMEOUT,
+) -> dict[str, Any]:
+    """Evaluate an organization by shelling out to the ``claude`` CLI.
+
+    Uses the caller's Claude Code session, so billing hits the Max
+    subscription rather than the per-token Anthropic API. Requires the
+    shell to be logged into Claude Code (``claude auth``). Not usable
+    from Lambda — Claude Code has no service-account mode.
+
+    Returns a schema-validated evaluation dict, just like ``evaluate_org``.
+    ``evaluated_by`` is stamped with a ``claude-code:`` prefix so the two
+    paths are distinguishable in stored records.
+    """
+    _validate_url(url)
+    user_content = _build_user_message(url, categories=categories)
+
+    cmd = [
+        "claude",
+        "-p", user_content,
+        "--append-system-prompt", SYSTEM_PROMPT,
+        "--tools", "WebSearch,WebFetch",
+        "--output-format", "json",
+        "--permission-mode", "dontAsk",
+        "--model", model,
+    ]
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if proc.returncode != 0:
+        msg = (
+            f"claude CLI exited with code {proc.returncode}: "
+            f"{proc.stderr[:500] or proc.stdout[:500]}"
+        )
+        raise RuntimeError(msg)
+
+    try:
+        envelope = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        msg = f"claude CLI stdout was not valid JSON: {exc}"
+        raise ValueError(msg) from exc
+
+    if envelope.get("is_error"):
+        msg = (
+            f"claude CLI reported error: "
+            f"{envelope.get('result', 'unknown')}"
+        )
+        raise RuntimeError(msg)
+
+    text = envelope.get("result", "")
+    if not text:
+        msg = "claude CLI envelope had no 'result' field"
+        raise ValueError(msg)
+
+    tool_use = envelope.get("usage", {}).get("server_tool_use", {})
+    logger.info(
+        "eval via claude-code url=%s cost_usd=%s "
+        "searches=%s fetches=%s",
+        url,
+        envelope.get("total_cost_usd"),
+        tool_use.get("web_search_requests"),
+        tool_use.get("web_fetch_requests"),
+    )
+
+    data = _extract_json(text)
+    _clean_response(data)
+
+    data["evaluated_at"] = (
+        datetime.datetime.now(datetime.UTC).isoformat()
+    )
+    data["evaluated_by"] = f"claude-code:{model}"
+    data["prompt_version"] = PROMPT_VERSION
+
+    try:
+        import jsonschema
+    except ImportError:
+        print(
+            "Error: jsonschema package not installed.\n"
+            "Install it with: poetry install",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    schema = _load_schema()
+    validator = jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    )
+    try:
+        validator.validate(data)
+    except jsonschema.ValidationError as exc:
+        msg = f"Claude Code output failed schema validation: {exc.message}"
+        raise ValueError(msg) from exc
+
+    return data
 
 
 def _save_evaluation(data: dict[str, Any], output_path: str) -> None:

--- a/backend/curation/evaluate.py
+++ b/backend/curation/evaluate.py
@@ -514,6 +514,9 @@ def _invoke_claude_cli(
         raise ValueError(msg)
 
     tool_use = envelope.get("usage", {}).get("server_tool_use", {})
+    # total_cost_usd is 0 on Max subscriptions (no per-token billing);
+    # kept for parity with the API-path usage log so the two sources
+    # can be grepped the same way.
     logger.info(
         "eval via claude-code url=%s cost_usd=%s "
         "searches=%s fetches=%s",

--- a/backend/curation/evaluate.py
+++ b/backend/curation/evaluate.py
@@ -372,17 +372,19 @@ def _validate_against_schema(
     """Validate *data* against ``schema.json``.
 
     Raises ``ValueError`` on mismatch with a message prefixed by
-    *source* (e.g. ``"Claude Code output"``).
+    *source* (e.g. ``"Claude Code output"``). Raises ``RuntimeError``
+    if ``jsonschema`` isn't installed — avoids ``sys.exit`` so callers
+    inside a Django management command can catch the failure and roll
+    the row back via CAS instead of hard-exiting mid-batch.
     """
     try:
         import jsonschema
-    except ImportError:
-        print(
-            "Error: jsonschema package not installed.\n"
-            "Install it with: poetry install",
-            file=sys.stderr,
+    except ImportError as exc:
+        msg = (
+            "jsonschema package not installed. "
+            "Install it with: poetry install"
         )
-        sys.exit(1)
+        raise RuntimeError(msg) from exc
 
     validator = jsonschema.Draft202012Validator(
         _load_schema(),

--- a/backend/curation/evaluate.py
+++ b/backend/curation/evaluate.py
@@ -366,6 +366,35 @@ def _build_user_message(
     return message
 
 
+def _validate_against_schema(
+    data: dict[str, Any], source: str = "Output",
+) -> None:
+    """Validate *data* against ``schema.json``.
+
+    Raises ``ValueError`` on mismatch with a message prefixed by
+    *source* (e.g. ``"Claude Code output"``).
+    """
+    try:
+        import jsonschema
+    except ImportError:
+        print(
+            "Error: jsonschema package not installed.\n"
+            "Install it with: poetry install",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    validator = jsonschema.Draft202012Validator(
+        _load_schema(),
+        format_checker=jsonschema.FormatChecker(),
+    )
+    try:
+        validator.validate(data)
+    except jsonschema.ValidationError as exc:
+        msg = f"{source} failed schema validation: {exc.message}"
+        raise ValueError(msg) from exc
+
+
 def evaluate_org(
     url: str,
     model: str,
@@ -435,26 +464,7 @@ def evaluate_org(
     result["evaluated_by"] = model
     result["prompt_version"] = PROMPT_VERSION
 
-    try:
-        import jsonschema
-    except ImportError:
-        print(
-            "Error: jsonschema package not installed.\n"
-            "Install it with: poetry install",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    schema = _load_schema()
-    validator = jsonschema.Draft202012Validator(
-        schema,
-        format_checker=jsonschema.FormatChecker(),
-    )
-    try:
-        validator.validate(result)
-    except jsonschema.ValidationError as exc:
-        msg = f"Output failed schema validation: {exc.message}"
-        raise ValueError(msg) from exc
+    _validate_against_schema(result, source="Output")
 
     return result
 
@@ -539,26 +549,7 @@ def evaluate_org_via_claude_code(
     data["evaluated_by"] = f"claude-code:{model}"
     data["prompt_version"] = PROMPT_VERSION
 
-    try:
-        import jsonschema
-    except ImportError:
-        print(
-            "Error: jsonschema package not installed.\n"
-            "Install it with: poetry install",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    schema = _load_schema()
-    validator = jsonschema.Draft202012Validator(
-        schema,
-        format_checker=jsonschema.FormatChecker(),
-    )
-    try:
-        validator.validate(data)
-    except jsonschema.ValidationError as exc:
-        msg = f"Claude Code output failed schema validation: {exc.message}"
-        raise ValueError(msg) from exc
+    _validate_against_schema(data, source="Claude Code output")
 
     return data
 

--- a/backend/curation/tests/test_evaluate.py
+++ b/backend/curation/tests/test_evaluate.py
@@ -516,6 +516,28 @@ class TestEvaluateOrgViaClaudeCode:
             )
 
 
+class TestValidateAgainstSchema:
+    """Error-path coverage for the shared schema validation helper."""
+
+    def test_raises_runtime_error_on_missing_jsonschema(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Missing jsonschema must raise, not sys.exit.
+
+        sys.exit inside a Django management command mid-batch would
+        bypass the CAS rollback that marks the row FAILED.
+        """
+        import sys as _sys
+
+        from curation.evaluate import _validate_against_schema
+
+        # Force `import jsonschema` inside the helper to raise ImportError.
+        monkeypatch.setitem(_sys.modules, "jsonschema", None)
+
+        with pytest.raises(RuntimeError, match="jsonschema"):
+            _validate_against_schema({}, source="Output")
+
+
 class TestCleanResponse:
     def test_known_activity_type_unchanged(self) -> None:
         data = {"evidence_of_work": [{"activity": "x", "type": "conservation"}]}

--- a/backend/curation/tests/test_evaluate.py
+++ b/backend/curation/tests/test_evaluate.py
@@ -515,6 +515,98 @@ class TestEvaluateOrgViaClaudeCode:
                 model="sonnet",
             )
 
+    def test_raises_on_malformed_stdout(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Non-JSON stdout must raise ValueError, not propagate JSONDecodeError."""
+        from curation.evaluate import evaluate_org_via_claude_code
+
+        self._patch_build_user_message(monkeypatch)
+
+        def fake_run(*_a: Any, **_kw: Any) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "this is not JSON at all {"
+            result.stderr = ""
+            return result
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        with pytest.raises(ValueError, match="not valid JSON"):
+            evaluate_org_via_claude_code(
+                "https://example.org",
+                model="sonnet",
+            )
+
+    def test_raises_on_empty_result_field(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Envelope with empty 'result' must raise ValueError."""
+        from curation.evaluate import evaluate_org_via_claude_code
+
+        self._patch_build_user_message(monkeypatch)
+
+        def fake_run(*_a: Any, **_kw: Any) -> MagicMock:
+            envelope = {"is_error": False, "result": "", "usage": {}}
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = json.dumps(envelope)
+            result.stderr = ""
+            return result
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        with pytest.raises(ValueError, match="no 'result' field"):
+            evaluate_org_via_claude_code(
+                "https://example.org",
+                model="sonnet",
+            )
+
+    def test_propagates_timeout_expired(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """subprocess.TimeoutExpired must propagate so callers can handle it."""
+        import subprocess as _subprocess
+
+        from curation.evaluate import evaluate_org_via_claude_code
+
+        self._patch_build_user_message(monkeypatch)
+
+        def fake_run(*_a: Any, **_kw: Any) -> MagicMock:
+            raise _subprocess.TimeoutExpired(cmd="claude", timeout=1)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        with pytest.raises(_subprocess.TimeoutExpired):
+            evaluate_org_via_claude_code(
+                "https://example.org",
+                model="sonnet",
+            )
+
+    def test_raises_on_schema_validation_failure(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Invalid Claude Code output must raise with a 'Claude Code' prefix.
+
+        Distinguishes this path from the API-based evaluate_org, whose
+        validation failure uses the bare 'Output' prefix.
+        """
+        from curation.evaluate import evaluate_org_via_claude_code
+
+        self._patch_build_user_message(monkeypatch)
+        invalid = {"org_metadata": {"name": "Test"}}  # missing required keys
+
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *_a, **_kw: self._fake_subprocess_result(invalid),
+        )
+
+        with pytest.raises(ValueError, match="Claude Code output"):
+            evaluate_org_via_claude_code(
+                "https://example.org",
+                model="sonnet",
+            )
+
 
 class TestValidateAgainstSchema:
     """Error-path coverage for the shared schema validation helper."""

--- a/backend/curation/tests/test_evaluate.py
+++ b/backend/curation/tests/test_evaluate.py
@@ -348,6 +348,174 @@ class TestEvaluateOrg:
             )
 
 
+class TestEvaluateOrgViaClaudeCode:
+    """Local Claude Code path — uses Max billing, shells out to `claude -p`."""
+
+    def _fake_subprocess_result(
+        self,
+        payload: dict[str, Any],
+        returncode: int = 0,
+        is_error: bool = False,
+    ) -> MagicMock:
+        envelope = {
+            "type": "result",
+            "subtype": "success",
+            "is_error": is_error,
+            "result": json.dumps(payload),
+            "total_cost_usd": 0.001,
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "server_tool_use": {
+                    "web_search_requests": 2,
+                    "web_fetch_requests": 1,
+                },
+            },
+        }
+        result = MagicMock()
+        result.returncode = returncode
+        result.stdout = json.dumps(envelope)
+        result.stderr = ""
+        return result
+
+    def _patch_build_user_message(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "curation.evaluate._build_user_message",
+            lambda *_a, **_kw: "fake user message",
+        )
+
+    def test_invokes_claude_cli_with_expected_flags(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from curation.evaluate import evaluate_org_via_claude_code
+
+        self._patch_build_user_message(monkeypatch)
+        eval_payload = _make_valid_evaluation()
+        del eval_payload["evaluated_at"]
+        del eval_payload["evaluated_by"]
+
+        captured_cmd: list[str] = []
+
+        def fake_run(cmd: list[str], **_kw: Any) -> MagicMock:
+            captured_cmd.extend(cmd)
+            return self._fake_subprocess_result(eval_payload)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        evaluate_org_via_claude_code(
+            "https://example.org",
+            model="sonnet",
+        )
+
+        # Must shell out to the claude CLI in print mode.
+        assert captured_cmd[0] == "claude"
+        assert "-p" in captured_cmd
+        # Must restrict tools to web access only.
+        tools_idx = captured_cmd.index("--tools")
+        assert captured_cmd[tools_idx + 1] == "WebSearch,WebFetch"
+        # Must use JSON envelope.
+        fmt_idx = captured_cmd.index("--output-format")
+        assert captured_cmd[fmt_idx + 1] == "json"
+        # Must pass the system prompt.
+        assert "--append-system-prompt" in captured_cmd
+        sys_idx = captured_cmd.index("--append-system-prompt")
+        assert captured_cmd[sys_idx + 1] == SYSTEM_PROMPT
+        # Must pass the model.
+        model_idx = captured_cmd.index("--model")
+        assert captured_cmd[model_idx + 1] == "sonnet"
+
+    def test_extracts_evaluation_from_envelope(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from curation.evaluate import evaluate_org_via_claude_code
+
+        self._patch_build_user_message(monkeypatch)
+        eval_payload = _make_valid_evaluation()
+        del eval_payload["evaluated_at"]
+        del eval_payload["evaluated_by"]
+
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *_a, **_kw: self._fake_subprocess_result(eval_payload),
+        )
+
+        result = evaluate_org_via_claude_code(
+            "https://example.org",
+            model="sonnet",
+        )
+
+        assert result["org_metadata"]["name"] == "Test Org"
+
+    def test_stamps_evaluated_by_with_claude_code_prefix(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`evaluated_by` must be distinguishable from the API path."""
+        from curation.evaluate import evaluate_org_via_claude_code
+
+        self._patch_build_user_message(monkeypatch)
+        eval_payload = _make_valid_evaluation()
+        del eval_payload["evaluated_at"]
+        del eval_payload["evaluated_by"]
+
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *_a, **_kw: self._fake_subprocess_result(eval_payload),
+        )
+
+        result = evaluate_org_via_claude_code(
+            "https://example.org",
+            model="sonnet",
+        )
+
+        assert result["evaluated_by"].startswith("claude-code:")
+        assert "sonnet" in result["evaluated_by"]
+
+    def test_raises_on_envelope_error(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from curation.evaluate import evaluate_org_via_claude_code
+
+        self._patch_build_user_message(monkeypatch)
+        eval_payload = _make_valid_evaluation()
+
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *_a, **_kw: self._fake_subprocess_result(
+                eval_payload, is_error=True,
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="error"):
+            evaluate_org_via_claude_code(
+                "https://example.org",
+                model="sonnet",
+            )
+
+    def test_raises_on_nonzero_exit(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from curation.evaluate import evaluate_org_via_claude_code
+
+        self._patch_build_user_message(monkeypatch)
+
+        def fake_run(*_a: Any, **_kw: Any) -> MagicMock:
+            result = MagicMock()
+            result.returncode = 2
+            result.stdout = ""
+            result.stderr = "auth failed"
+            return result
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        with pytest.raises(RuntimeError, match="claude"):
+            evaluate_org_via_claude_code(
+                "https://example.org",
+                model="sonnet",
+            )
+
+
 class TestCleanResponse:
     def test_known_activity_type_unchanged(self) -> None:
         data = {"evidence_of_work": [{"activity": "x", "type": "conservation"}]}

--- a/backend/curation/tests/test_evaluate.py
+++ b/backend/curation/tests/test_evaluate.py
@@ -487,7 +487,7 @@ class TestEvaluateOrgViaClaudeCode:
             ),
         )
 
-        with pytest.raises(RuntimeError, match="error"):
+        with pytest.raises(RuntimeError, match="CLI reported error"):
             evaluate_org_via_claude_code(
                 "https://example.org",
                 model="sonnet",
@@ -509,7 +509,7 @@ class TestEvaluateOrgViaClaudeCode:
 
         monkeypatch.setattr("subprocess.run", fake_run)
 
-        with pytest.raises(RuntimeError, match="claude"):
+        with pytest.raises(RuntimeError, match="exited with code"):
             evaluate_org_via_claude_code(
                 "https://example.org",
                 model="sonnet",

--- a/backend/terramedic/nominations/claim.py
+++ b/backend/terramedic/nominations/claim.py
@@ -61,26 +61,34 @@ def evaluate_org(
     return _evaluate_org(url=url, model=model, client=client, categories=categories)
 
 
-def claim_nominations(limit: int) -> Generator[Nomination]:
-    """Claim queued nominations atomically and yield non-skipped ones.
+def claim_nominations(
+    limit: int,
+    from_status: str = NominationStatus.QUEUED,
+) -> Generator[Nomination]:
+    """Claim nominations atomically and yield non-skipped ones.
 
-    For each queued nomination (up to *limit*):
+    The AWS worker claims from ``QUEUED`` (the default). A local
+    curator-run command can claim from ``PENDING`` to bypass the SQS
+    pipeline — the two pools are disjoint so the worker and a local
+    run can't race for the same row.
+
+    For each nomination in ``from_status`` (up to *limit*):
     1. Atomically set status to EVALUATING and increment attempts.
-    2. Revert to PENDING if the URL should be skipped.
+    2. Revert to ``from_status`` if the URL should be skipped.
     3. Yield the nomination if it passed both checks.
     """
     nominations = list(
         Nomination.objects.filter(
-            status=NominationStatus.QUEUED,
+            status=from_status,
         ).order_by("submitted_at")[:limit],
     )
 
     for nomination in nominations:
-        # Atomic claim: only proceed if still queued (prevents
-        # duplicate processing by concurrent workers).
+        # Atomic claim: only proceed if still in the source status
+        # (prevents duplicate processing by concurrent workers).
         claimed = Nomination.objects.filter(
             pk=nomination.pk,
-            status=NominationStatus.QUEUED,
+            status=from_status,
         ).update(
             status=NominationStatus.EVALUATING,
             evaluation_attempts=F("evaluation_attempts") + 1,
@@ -91,6 +99,12 @@ def claim_nominations(limit: int) -> Generator[Nomination]:
         nomination.refresh_from_db()
 
         if should_skip_url(nomination.url):
+            # Always revert to PENDING so skipworthy rows exit the
+            # active queue. For QUEUED → this breaks the worker's
+            # claim-skip-revert loop. For PENDING → the local command
+            # pre-filters via build_skip_urls so this path is a rare
+            # race fallback; staying in PENDING is fine because the
+            # pre-filter will exclude it again on the next run.
             nomination.status = NominationStatus.PENDING
             nomination.evaluation_attempts -= 1
             nomination.save(

--- a/backend/terramedic/nominations/claim.py
+++ b/backend/terramedic/nominations/claim.py
@@ -74,7 +74,10 @@ def claim_nominations(
 
     For each nomination in ``from_status`` (up to *limit*):
     1. Atomically set status to EVALUATING and increment attempts.
-    2. Revert to ``from_status`` if the URL should be skipped.
+    2. Revert to ``PENDING`` if the URL should be skipped — always
+       PENDING, regardless of ``from_status``, so skipworthy rows
+       exit the active ``QUEUED`` pool (prevents the worker's
+       claim-skip-revert loop).
     3. Yield the nomination if it passed both checks.
     """
     nominations = list(

--- a/backend/terramedic/nominations/management/commands/evaluate_pending.py
+++ b/backend/terramedic/nominations/management/commands/evaluate_pending.py
@@ -140,9 +140,12 @@ class Command(BaseCommand):
         skip_urls = build_skip_urls(set(pending_urls))
         if not skip_urls:
             return
+        # Count nominations, not URLs: Nomination.url is not unique,
+        # so multiple PENDING rows may share a skipworthy URL.
+        skipped_count = sum(url in skip_urls for url in pending_urls)
         self.stdout.write(
             self.style.WARNING(
-                f"Skipping {len(skip_urls)} PENDING nomination(s) "
+                f"Skipping {skipped_count} PENDING nomination(s) "
                 "(already evaluated, already an organization, "
                 "or in 90-day cooldown):",
             ),

--- a/backend/terramedic/nominations/management/commands/evaluate_pending.py
+++ b/backend/terramedic/nominations/management/commands/evaluate_pending.py
@@ -1,0 +1,132 @@
+"""Evaluate PENDING nominations locally via Claude Code (Max billing).
+
+Shells out to the ``claude`` CLI for each claimed nomination, so the
+cost hits the operator's Max subscription rather than the per-token
+Anthropic API used by the SQS/Lambda pipeline.
+
+Usage:
+    SECRET_KEY=... DEBUG=true \\
+        poetry run python manage.py evaluate_pending --limit 10
+
+Notes:
+- Only touches ``PENDING`` nominations. The AWS pipeline claims
+  ``QUEUED``, so the two pools are disjoint — no race.
+- Pre-filters duplicate URLs via ``build_skip_urls`` and reports them;
+  those nominations stay in ``PENDING`` for the curator to triage.
+- Requires an interactive Claude Code login (``claude auth``). Not
+  usable from a headless server.
+"""
+
+import logging
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from curation.evaluate import evaluate_org_via_claude_code
+from terramedic.nominations.claim import claim_nominations
+from terramedic.nominations.models import Nomination, NominationStatus
+from terramedic.nominations.skip_checks import build_skip_urls
+from terramedic.organizations.models import OrganizationEvaluation
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Evaluate PENDING nominations locally via Claude Code "
+        "(uses Max subscription, not API credits)."
+    )
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=10,
+            help="Maximum nominations to evaluate (default: 10).",
+        )
+        parser.add_argument(
+            "--model",
+            default="sonnet",
+            help=(
+                "Claude Code model alias or full name "
+                "(default: sonnet)."
+            ),
+        )
+
+    def handle(self, *_args: Any, **options: Any) -> None:
+        limit: int = options["limit"]
+        model: str = options["model"]
+
+        self._report_skips(limit)
+
+        processed = 0
+        failed = 0
+
+        for nomination in claim_nominations(
+            limit, from_status=NominationStatus.PENDING,
+        ):
+            self.stdout.write(f"Evaluating {nomination.url} ...")
+            try:
+                data = evaluate_org_via_claude_code(
+                    url=nomination.url,
+                    model=model,
+                    categories=nomination.categories or None,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception(
+                    "evaluate_org_via_claude_code failed for %s",
+                    nomination.url,
+                )
+                Nomination.objects.filter(pk=nomination.pk).update(
+                    status=NominationStatus.FAILED,
+                )
+                self.stdout.write(
+                    self.style.ERROR(f"  FAILED: {exc}"),
+                )
+                failed += 1
+                continue
+
+            curator_notes = data.get("curator_notes", {})
+            OrganizationEvaluation.objects.create(
+                evaluation_data=data,
+                ai_model=data.get("evaluated_by", ""),
+                ai_recommendation=curator_notes.get(
+                    "recommendation", "",
+                ),
+                ai_confidence=curator_notes.get("confidence"),
+                nomination=nomination,
+            )
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"  saved evaluation for {nomination.url}",
+                ),
+            )
+            processed += 1
+
+        self.stdout.write(
+            f"Done. Evaluated {processed}, failed {failed}.",
+        )
+
+    def _report_skips(self, limit: int) -> None:
+        """Report PENDING URLs that are duplicates and will be skipped."""
+        pending_urls = list(
+            Nomination.objects.filter(
+                status=NominationStatus.PENDING,
+            ).order_by("submitted_at").values_list(
+                "url", flat=True,
+            )[:limit],
+        )
+        if not pending_urls:
+            return
+        skip_urls = build_skip_urls(set(pending_urls))
+        if not skip_urls:
+            return
+        self.stdout.write(
+            self.style.WARNING(
+                f"Skipping {len(skip_urls)} PENDING nomination(s) "
+                "(already evaluated, already an organization, "
+                "or in 90-day cooldown):",
+            ),
+        )
+        for url in sorted(skip_urls):
+            self.stdout.write(f"  - {url}")

--- a/backend/terramedic/nominations/management/commands/evaluate_pending.py
+++ b/backend/terramedic/nominations/management/commands/evaluate_pending.py
@@ -77,9 +77,28 @@ class Command(BaseCommand):
                     "evaluate_org_via_claude_code failed for %s",
                     nomination.url,
                 )
-                Nomination.objects.filter(pk=nomination.pk).update(
-                    status=NominationStatus.FAILED,
-                )
+                # Conditional CAS on (status, evaluation_attempts) so a
+                # concurrent change — sweep_stuck_claims retiring the
+                # row, a manual admin edit, or a parallel run — isn't
+                # stomped. Mirrors worker._handle_results.
+                updated = Nomination.objects.filter(
+                    pk=nomination.pk,
+                    status=NominationStatus.EVALUATING,
+                    evaluation_attempts=nomination.evaluation_attempts,
+                ).update(status=NominationStatus.FAILED)
+                if updated == 0:
+                    logger.warning(
+                        "Skipping FAILED update for nomination %s; "
+                        "row changed concurrently",
+                        nomination.pk,
+                    )
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"  skipped FAILED update for {nomination.url}: "
+                            "row changed concurrently",
+                        ),
+                    )
+                    continue
                 self.stdout.write(
                     self.style.ERROR(f"  FAILED: {exc}"),
                 )

--- a/backend/terramedic/nominations/management/commands/evaluate_pending.py
+++ b/backend/terramedic/nominations/management/commands/evaluate_pending.py
@@ -120,10 +120,6 @@ class Command(BaseCommand):
 
     def _handle_timeout(self, nomination: Nomination) -> str:
         """Revert EVALUATING → PENDING on CLI timeout via CAS."""
-        logger.warning(
-            "claude CLI timed out for %s; reverting to PENDING",
-            nomination.url,
-        )
         reverted = Nomination.objects.filter(
             pk=nomination.pk,
             status=NominationStatus.EVALUATING,
@@ -167,11 +163,6 @@ class Command(BaseCommand):
             evaluation_attempts=nomination.evaluation_attempts,
         ).update(status=NominationStatus.FAILED)
         if updated == 0:
-            logger.warning(
-                "Skipping FAILED update for nomination %s; "
-                "row changed concurrently",
-                nomination.pk,
-            )
             self.stdout.write(
                 self.style.WARNING(
                     f"  skipped FAILED update for {nomination.url}: "

--- a/backend/terramedic/nominations/management/commands/evaluate_pending.py
+++ b/backend/terramedic/nominations/management/commands/evaluate_pending.py
@@ -160,7 +160,14 @@ class Command(BaseCommand):
         )
 
     def _report_skips(self, limit: int) -> None:
-        """Report PENDING URLs that are duplicates and will be skipped."""
+        """Report PENDING URLs that are duplicates and will be skipped.
+
+        Diagnostic only. The subsequent ``claim_nominations`` call runs
+        its own PENDING query and will re-check skipworthiness row-by-row
+        via ``should_skip_url`` — this preview can disagree if a new
+        PENDING row is inserted between the two queries. That's fine:
+        the authoritative skip happens inside the claim loop.
+        """
         pending_urls = list(
             Nomination.objects.filter(
                 status=NominationStatus.PENDING,

--- a/backend/terramedic/nominations/management/commands/evaluate_pending.py
+++ b/backend/terramedic/nominations/management/commands/evaluate_pending.py
@@ -203,12 +203,14 @@ class Command(BaseCommand):
         skip_urls = build_skip_urls(set(pending_urls))
         if not skip_urls:
             return
-        # Count nominations, not URLs: Nomination.url is not unique,
-        # so multiple PENDING rows may share a skipworthy URL.
+        # Report both counts: Nomination.url is not unique, so the
+        # nomination count and URL count may differ when multiple
+        # PENDING rows share a skipworthy URL.
         skipped_count = sum(url in skip_urls for url in pending_urls)
         self.stdout.write(
             self.style.WARNING(
                 f"Skipping {skipped_count} PENDING nomination(s) "
+                f"matching {len(skip_urls)} unique URL(s) "
                 "(already evaluated, already an organization, "
                 "or in 90-day cooldown):",
             ),

--- a/backend/terramedic/nominations/management/commands/evaluate_pending.py
+++ b/backend/terramedic/nominations/management/commands/evaluate_pending.py
@@ -18,9 +18,11 @@ Notes:
 """
 
 import logging
+import subprocess
 from typing import Any
 
 from django.core.management.base import BaseCommand
+from django.db.models import F
 
 from curation.evaluate import evaluate_org_via_claude_code
 from terramedic.nominations.claim import claim_nominations
@@ -72,6 +74,37 @@ class Command(BaseCommand):
                     model=model,
                     categories=nomination.categories or None,
                 )
+            except subprocess.TimeoutExpired:
+                # Timeouts are likely transient — revert to PENDING so
+                # the curator can re-run. CAS mirrors the FAILED path
+                # below. Claim incremented evaluation_attempts; decrement
+                # back so a re-run starts from the same attempt count.
+                logger.warning(
+                    "claude CLI timed out for %s; reverting to PENDING",
+                    nomination.url,
+                )
+                reverted = Nomination.objects.filter(
+                    pk=nomination.pk,
+                    status=NominationStatus.EVALUATING,
+                    evaluation_attempts=nomination.evaluation_attempts,
+                ).update(
+                    status=NominationStatus.PENDING,
+                    evaluation_attempts=F("evaluation_attempts") - 1,
+                )
+                if reverted == 0:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"  timeout revert skipped for {nomination.url}: "
+                            "row changed concurrently",
+                        ),
+                    )
+                    continue
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  TIMED OUT (reverted to PENDING): {nomination.url}",
+                    ),
+                )
+                continue
             except Exception as exc:  # noqa: BLE001
                 logger.exception(
                     "evaluate_org_via_claude_code failed for %s",

--- a/backend/terramedic/nominations/management/commands/evaluate_pending.py
+++ b/backend/terramedic/nominations/management/commands/evaluate_pending.py
@@ -98,6 +98,9 @@ class Command(BaseCommand):
         except subprocess.TimeoutExpired:
             return self._handle_timeout(nomination)
         except Exception as exc:  # noqa: BLE001
+            # Broad catch is intentional — any Claude Code failure
+            # (schema, network, CLI crash, JSON parse) should mark this
+            # row FAILED and let the rest of the batch continue.
             return self._handle_failure(nomination, exc)
 
         curator_notes = data.get("curator_notes", {})

--- a/backend/terramedic/nominations/management/commands/evaluate_pending.py
+++ b/backend/terramedic/nominations/management/commands/evaluate_pending.py
@@ -68,96 +68,116 @@ class Command(BaseCommand):
             limit, from_status=NominationStatus.PENDING,
         ):
             self.stdout.write(f"Evaluating {nomination.url} ...")
-            try:
-                data = evaluate_org_via_claude_code(
-                    url=nomination.url,
-                    model=model,
-                    categories=nomination.categories or None,
-                )
-            except subprocess.TimeoutExpired:
-                # Timeouts are likely transient — revert to PENDING so
-                # the curator can re-run. CAS mirrors the FAILED path
-                # below. Claim incremented evaluation_attempts; decrement
-                # back so a re-run starts from the same attempt count.
-                logger.warning(
-                    "claude CLI timed out for %s; reverting to PENDING",
-                    nomination.url,
-                )
-                reverted = Nomination.objects.filter(
-                    pk=nomination.pk,
-                    status=NominationStatus.EVALUATING,
-                    evaluation_attempts=nomination.evaluation_attempts,
-                ).update(
-                    status=NominationStatus.PENDING,
-                    evaluation_attempts=F("evaluation_attempts") - 1,
-                )
-                if reverted == 0:
-                    self.stdout.write(
-                        self.style.WARNING(
-                            f"  timeout revert skipped for {nomination.url}: "
-                            "row changed concurrently",
-                        ),
-                    )
-                    continue
-                self.stdout.write(
-                    self.style.WARNING(
-                        f"  TIMED OUT (reverted to PENDING): {nomination.url}",
-                    ),
-                )
-                continue
-            except Exception as exc:  # noqa: BLE001
-                logger.exception(
-                    "evaluate_org_via_claude_code failed for %s",
-                    nomination.url,
-                )
-                # Conditional CAS on (status, evaluation_attempts) so a
-                # concurrent change — sweep_stuck_claims retiring the
-                # row, a manual admin edit, or a parallel run — isn't
-                # stomped. Mirrors worker._handle_results.
-                updated = Nomination.objects.filter(
-                    pk=nomination.pk,
-                    status=NominationStatus.EVALUATING,
-                    evaluation_attempts=nomination.evaluation_attempts,
-                ).update(status=NominationStatus.FAILED)
-                if updated == 0:
-                    logger.warning(
-                        "Skipping FAILED update for nomination %s; "
-                        "row changed concurrently",
-                        nomination.pk,
-                    )
-                    self.stdout.write(
-                        self.style.WARNING(
-                            f"  skipped FAILED update for {nomination.url}: "
-                            "row changed concurrently",
-                        ),
-                    )
-                    continue
-                self.stdout.write(
-                    self.style.ERROR(f"  FAILED: {exc}"),
-                )
+            outcome = self._process_one(nomination, model)
+            if outcome == "ok":
+                processed += 1
+            elif outcome == "failed":
                 failed += 1
-                continue
-
-            curator_notes = data.get("curator_notes", {})
-            OrganizationEvaluation.objects.create(
-                evaluation_data=data,
-                ai_model=data.get("evaluated_by", ""),
-                ai_recommendation=curator_notes.get(
-                    "recommendation", "",
-                ),
-                ai_confidence=curator_notes.get("confidence"),
-                nomination=nomination,
-            )
-            self.stdout.write(
-                self.style.SUCCESS(
-                    f"  saved evaluation for {nomination.url}",
-                ),
-            )
-            processed += 1
+            # "timeout" and "raced" don't count toward failed — the row
+            # is back in PENDING or otherwise untouched.
 
         self.stdout.write(
             f"Done. Evaluated {processed}, failed {failed}.",
         )
+
+    def _process_one(
+        self, nomination: Nomination, model: str,
+    ) -> str:
+        """Evaluate one claimed nomination. Returns outcome label.
+
+        Returns ``"ok"`` on success, ``"failed"`` if marked FAILED,
+        ``"timeout"`` if reverted to PENDING on CLI timeout, or
+        ``"raced"`` if a CAS found the row was changed concurrently.
+        """
+        try:
+            data = evaluate_org_via_claude_code(
+                url=nomination.url,
+                model=model,
+                categories=nomination.categories or None,
+            )
+        except subprocess.TimeoutExpired:
+            return self._handle_timeout(nomination)
+        except Exception as exc:  # noqa: BLE001
+            return self._handle_failure(nomination, exc)
+
+        curator_notes = data.get("curator_notes", {})
+        OrganizationEvaluation.objects.create(
+            evaluation_data=data,
+            ai_model=data.get("evaluated_by", ""),
+            ai_recommendation=curator_notes.get("recommendation", ""),
+            ai_confidence=curator_notes.get("confidence"),
+            nomination=nomination,
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"  saved evaluation for {nomination.url}",
+            ),
+        )
+        return "ok"
+
+    def _handle_timeout(self, nomination: Nomination) -> str:
+        """Revert EVALUATING → PENDING on CLI timeout via CAS."""
+        logger.warning(
+            "claude CLI timed out for %s; reverting to PENDING",
+            nomination.url,
+        )
+        reverted = Nomination.objects.filter(
+            pk=nomination.pk,
+            status=NominationStatus.EVALUATING,
+            evaluation_attempts=nomination.evaluation_attempts,
+        ).update(
+            status=NominationStatus.PENDING,
+            evaluation_attempts=F("evaluation_attempts") - 1,
+        )
+        if reverted == 0:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"  timeout revert skipped for {nomination.url}: "
+                    "row changed concurrently",
+                ),
+            )
+            return "raced"
+        self.stdout.write(
+            self.style.WARNING(
+                f"  TIMED OUT (reverted to PENDING): {nomination.url}",
+            ),
+        )
+        return "timeout"
+
+    def _handle_failure(
+        self, nomination: Nomination, exc: Exception,
+    ) -> str:
+        """Mark EVALUATING → FAILED on any other exception via CAS.
+
+        Conditional on (status, evaluation_attempts) so a concurrent
+        change — sweep_stuck_claims retiring the row, a manual admin
+        edit, or a parallel run — isn't stomped. Mirrors
+        worker._handle_results.
+        """
+        logger.exception(
+            "evaluate_org_via_claude_code failed for %s",
+            nomination.url,
+        )
+        updated = Nomination.objects.filter(
+            pk=nomination.pk,
+            status=NominationStatus.EVALUATING,
+            evaluation_attempts=nomination.evaluation_attempts,
+        ).update(status=NominationStatus.FAILED)
+        if updated == 0:
+            logger.warning(
+                "Skipping FAILED update for nomination %s; "
+                "row changed concurrently",
+                nomination.pk,
+            )
+            self.stdout.write(
+                self.style.WARNING(
+                    f"  skipped FAILED update for {nomination.url}: "
+                    "row changed concurrently",
+                ),
+            )
+            return "raced"
+        self.stdout.write(self.style.ERROR(f"  FAILED: {exc}"))
+        return "failed"
 
     def _report_skips(self, limit: int) -> None:
         """Report PENDING URLs that are duplicates and will be skipped.

--- a/backend/terramedic/nominations/tests/conftest.py
+++ b/backend/terramedic/nominations/tests/conftest.py
@@ -42,3 +42,17 @@ def make_queued_nomination(
         ip_hash=None,
         status=NominationStatus.QUEUED,
     )
+
+
+def make_pending_nomination(
+    url: str = "https://example.org",
+) -> Any:
+    """Create a Nomination in PENDING status for testing."""
+    from terramedic.nominations.models import Nomination, NominationStatus
+
+    return Nomination.objects.create(
+        url=url,
+        categories=["volunteer"],
+        ip_hash=None,
+        status=NominationStatus.PENDING,
+    )

--- a/backend/terramedic/nominations/tests/test_claim.py
+++ b/backend/terramedic/nominations/tests/test_claim.py
@@ -11,7 +11,10 @@ from terramedic.nominations.claim import (
     sweep_stuck_claims,
 )
 from terramedic.nominations.models import Nomination, NominationStatus
-from terramedic.nominations.tests.conftest import make_queued_nomination
+from terramedic.nominations.tests.conftest import (
+    make_pending_nomination,
+    make_queued_nomination,
+)
 
 
 @pytest.mark.django_db
@@ -87,6 +90,66 @@ class TestClaimNominations:
         nom.refresh_from_db()
         assert nom.claimed_at is not None
         assert nom.claimed_at >= before
+
+    def test_default_from_status_is_queued_ignores_pending(self) -> None:
+        """Backward-compat: default claim still ignores PENDING rows."""
+        make_pending_nomination("https://pending.org")
+        make_queued_nomination("https://queued.org")
+
+        result = list(claim_nominations(limit=10))
+
+        urls = {n.url for n in result}
+        assert urls == {"https://queued.org"}
+
+    def test_from_status_pending_claims_pending(self) -> None:
+        """Local command path: claim PENDING, leave QUEUED alone."""
+        make_pending_nomination("https://pending.org")
+        make_queued_nomination("https://queued.org")
+
+        result = list(
+            claim_nominations(
+                limit=10,
+                from_status=NominationStatus.PENDING,
+            ),
+        )
+
+        urls = {n.url for n in result}
+        assert urls == {"https://pending.org"}
+
+    def test_from_status_pending_transitions_to_evaluating(self) -> None:
+        nom = make_pending_nomination()
+
+        list(
+            claim_nominations(
+                limit=10,
+                from_status=NominationStatus.PENDING,
+            ),
+        )
+
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.EVALUATING
+
+    @patch(
+        "terramedic.nominations.claim.should_skip_url",
+        return_value=True,
+    )
+    def test_from_status_pending_reverts_skipworthy_to_pending(
+        self, mock_skip: object,  # noqa: ARG002
+    ) -> None:
+        """On skip, revert to the source status (not hardcoded PENDING)."""
+        nom = make_pending_nomination()
+
+        result = list(
+            claim_nominations(
+                limit=10,
+                from_status=NominationStatus.PENDING,
+            ),
+        )
+
+        assert len(result) == 0
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.PENDING
+        assert nom.evaluation_attempts == 0
 
 
 @pytest.mark.django_db

--- a/backend/terramedic/nominations/tests/test_claim.py
+++ b/backend/terramedic/nominations/tests/test_claim.py
@@ -136,7 +136,7 @@ class TestClaimNominations:
     def test_from_status_pending_reverts_skipworthy_to_pending(
         self, mock_skip: object,  # noqa: ARG002
     ) -> None:
-        """On skip, revert to the source status (not hardcoded PENDING)."""
+        """On skip, always revert to PENDING regardless of from_status."""
         nom = make_pending_nomination()
 
         result = list(

--- a/backend/terramedic/nominations/tests/test_evaluate_pending.py
+++ b/backend/terramedic/nominations/tests/test_evaluate_pending.py
@@ -1,0 +1,146 @@
+"""Tests for the evaluate_pending management command.
+
+This command shells out to Claude Code (not the Anthropic API) so evals
+hit the user's Max subscription instead of per-token API billing.
+"""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+
+from terramedic.nominations.models import NominationStatus
+from terramedic.nominations.tests.conftest import (
+    EVAL_RESULT,
+    make_pending_nomination,
+    make_queued_nomination,
+)
+from terramedic.organizations.models import OrganizationEvaluation
+
+_COMMAND = "evaluate_pending"
+
+_EVAL_VIA_CC_PATH = (
+    "terramedic.nominations.management.commands"
+    ".evaluate_pending.evaluate_org_via_claude_code"
+)
+
+
+@pytest.mark.django_db
+class TestEvaluatePending:
+    @patch(_EVAL_VIA_CC_PATH, return_value=EVAL_RESULT)
+    def test_processes_pending_nomination(
+        self, mock_eval: Any,  # noqa: ARG002
+    ) -> None:
+        nom = make_pending_nomination()
+        call_command(_COMMAND)
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.EVALUATED
+
+    @patch(_EVAL_VIA_CC_PATH, return_value=EVAL_RESULT)
+    def test_leaves_queued_untouched(
+        self, mock_eval: Any,  # noqa: ARG002
+    ) -> None:
+        """QUEUED is the AWS worker's pool. Local command must not touch it."""
+        queued = make_queued_nomination("https://queued.org")
+        pending = make_pending_nomination("https://pending.org")
+
+        call_command(_COMMAND)
+
+        queued.refresh_from_db()
+        pending.refresh_from_db()
+        assert queued.status == NominationStatus.QUEUED
+        assert pending.status == NominationStatus.EVALUATED
+
+    @patch(_EVAL_VIA_CC_PATH, return_value=EVAL_RESULT)
+    def test_links_evaluation_to_nomination(
+        self, mock_eval: Any,  # noqa: ARG002
+    ) -> None:
+        nom = make_pending_nomination()
+        call_command(_COMMAND)
+        ev = OrganizationEvaluation.objects.get(nomination=nom)
+        assert ev.nomination_id == nom.pk
+
+    @patch(_EVAL_VIA_CC_PATH, side_effect=RuntimeError("claude failed"))
+    def test_failure_marks_failed(
+        self, mock_eval: Any,  # noqa: ARG002
+    ) -> None:
+        nom = make_pending_nomination()
+        call_command(_COMMAND)
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.FAILED
+
+    @patch(_EVAL_VIA_CC_PATH, return_value=EVAL_RESULT)
+    def test_passes_categories_to_claude_code(
+        self, mock_eval: Any,
+    ) -> None:
+        from terramedic.nominations.models import Nomination
+
+        Nomination.objects.create(
+            url="https://with-cats.org",
+            categories=["donate", "resource"],
+            status=NominationStatus.PENDING,
+            ip_hash=None,
+        )
+
+        call_command(_COMMAND)
+
+        assert mock_eval.call_count == 1
+        call_kwargs = mock_eval.call_args.kwargs
+        assert call_kwargs.get("categories") == ["donate", "resource"]
+
+    @patch(_EVAL_VIA_CC_PATH, return_value=EVAL_RESULT)
+    def test_respects_limit(self, mock_eval: Any) -> None:
+        make_pending_nomination("https://one.org")
+        make_pending_nomination("https://two.org")
+        make_pending_nomination("https://three.org")
+
+        call_command(_COMMAND, "--limit", "2")
+
+        assert mock_eval.call_count == 2
+
+
+@pytest.mark.django_db
+class TestSkipBehavior:
+    """Duplicate URLs must not be evaluated; the skip is driven by real
+    DB state (existing org or active evaluation), exercised end-to-end."""
+
+    @patch(_EVAL_VIA_CC_PATH, return_value=EVAL_RESULT)
+    def test_url_matching_existing_org_is_not_evaluated(
+        self, mock_eval: Any,
+    ) -> None:
+        from terramedic.organizations.models import Organization
+
+        Organization.objects.create(
+            name="Existing",
+            website_url="https://dup.org",
+        )
+        nom = make_pending_nomination("https://dup.org")
+
+        call_command(_COMMAND)
+
+        assert mock_eval.call_count == 0
+        nom.refresh_from_db()
+        # claim_nominations claims then reverts on skip → back to PENDING.
+        assert nom.status == NominationStatus.PENDING
+
+    @patch(_EVAL_VIA_CC_PATH, return_value=EVAL_RESULT)
+    def test_mixed_batch_skips_only_duplicates(
+        self, mock_eval: Any,
+    ) -> None:
+        from terramedic.organizations.models import Organization
+
+        Organization.objects.create(
+            name="Existing",
+            website_url="https://dup.org",
+        )
+        dup = make_pending_nomination("https://dup.org")
+        fresh = make_pending_nomination("https://fresh.org")
+
+        call_command(_COMMAND)
+
+        assert mock_eval.call_count == 1
+        dup.refresh_from_db()
+        fresh.refresh_from_db()
+        assert dup.status == NominationStatus.PENDING
+        assert fresh.status == NominationStatus.EVALUATED

--- a/backend/terramedic/nominations/tests/test_evaluate_pending.py
+++ b/backend/terramedic/nominations/tests/test_evaluate_pending.py
@@ -70,6 +70,29 @@ class TestEvaluatePending:
         nom.refresh_from_db()
         assert nom.status == NominationStatus.FAILED
 
+    def test_failure_skips_cas_when_row_changed(self) -> None:
+        """Concurrent change between claim and FAILED update → no-op."""
+        from terramedic.nominations.models import Nomination
+
+        nom = make_pending_nomination()
+
+        def mid_eval_stomp(*_a: Any, **_kw: Any) -> None:
+            # Simulate sweep_stuck_claims or admin edit stomping the row
+            # while Claude Code is mid-evaluation.
+            Nomination.objects.filter(pk=nom.pk).update(
+                status=NominationStatus.FAILED,
+            )
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        with patch(_EVAL_VIA_CC_PATH, side_effect=mid_eval_stomp):
+            call_command(_COMMAND)
+
+        # Status already FAILED from the stomp — CAS saw no EVALUATING
+        # row to transition, so no additional update happened.
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.FAILED
+
     @patch(_EVAL_VIA_CC_PATH, return_value=EVAL_RESULT)
     def test_passes_categories_to_claude_code(
         self, mock_eval: Any,

--- a/backend/terramedic/nominations/tests/test_evaluate_pending.py
+++ b/backend/terramedic/nominations/tests/test_evaluate_pending.py
@@ -70,6 +70,27 @@ class TestEvaluatePending:
         nom.refresh_from_db()
         assert nom.status == NominationStatus.FAILED
 
+    def test_timeout_reverts_to_pending(self) -> None:
+        """subprocess.TimeoutExpired reverts the row to PENDING.
+
+        Unlike FAILED (permanent), a timeout is likely transient —
+        curator can re-run the command and the row will be re-claimed.
+        """
+        import subprocess as _subprocess
+
+        nom = make_pending_nomination()
+
+        with patch(
+            _EVAL_VIA_CC_PATH,
+            side_effect=_subprocess.TimeoutExpired(cmd="claude", timeout=1),
+        ):
+            call_command(_COMMAND)
+
+        nom.refresh_from_db()
+        assert nom.status == NominationStatus.PENDING
+        # Claim incremented attempts to 1; revert decrements back to 0.
+        assert nom.evaluation_attempts == 0
+
     def test_failure_skips_cas_when_row_changed(self) -> None:
         """Concurrent change between claim and FAILED update → no-op."""
         from terramedic.nominations.models import Nomination


### PR DESCRIPTION
## Summary

Adds a Django management command that a curator runs locally to evaluate a batch of nominations through their Claude Code session — so the cost hits the **Max subscription** instead of per-token Anthropic API billing. Complements (doesn't replace) the SQS/Lambda pipeline.

```bash
SECRET_KEY=... DEBUG=true poetry run python manage.py evaluate_pending --limit 10
```

## How the two paths stay disjoint

| | AWS pipeline | Local command |
|---|---|---|
| Claim pool | `QUEUED` | `PENDING` |
| Billing | API (per-token) | Max (flat) |
| Runs in Lambda | Yes | No |
| Trigger | SQS | Curator invokes |

Because the pools are disjoint, the worker and a local run can never race for the same row. A curator chooses a path per-nomination: mark `QUEUED` to send it through AWS, or leave `PENDING` and run the local command.

## What's in the change

**1. `claim_nominations(limit, from_status=QUEUED)`** — new `from_status` param. Default preserves AWS worker behavior; the command passes `PENDING`. Skip-reverts always go to `PENDING` regardless of source, so skipworthy URLs still exit the active `QUEUED` pool (the original loop-prevention contract).

**2. `evaluate_org_via_claude_code(url, model, categories, timeout)`** — shells out to `claude -p`:

```
claude -p <user message>
  --append-system-prompt <SYSTEM_PROMPT>
  --tools WebSearch,WebFetch
  --output-format json
  --permission-mode dontAsk
  --model sonnet
```

Parses the JSON envelope (`result` field = model's text, `is_error`, `total_cost_usd`, `usage.server_tool_use`). Logs cost + search/fetch counts per call. Stamps `evaluated_by` with a `claude-code:` prefix so records from the two paths are distinguishable.

**3. `evaluate_pending` management command**:
- Reports duplicate URLs up front via `build_skip_urls` (existing helper): "Skipping N PENDING nomination(s) (already evaluated, already an org, or in 90-day cooldown): <urls>"
- Claims from `PENDING` via `claim_nominations(limit, from_status=PENDING)`
- Calls `evaluate_org_via_claude_code` for each; on success creates an `OrganizationEvaluation` linked to the nomination (the existing `sync_nomination_status` signal then flips `EVALUATING → EVALUATED`)
- On failure: marks nomination `FAILED` via conditional `UPDATE`, logs, keeps going

## Files touched

- `backend/terramedic/nominations/claim.py` — `from_status` param.
- `backend/curation/evaluate.py` — new `evaluate_org_via_claude_code`.
- `backend/terramedic/nominations/management/commands/evaluate_pending.py` (new).
- `backend/terramedic/nominations/tests/test_claim.py` — 4 new tests for `from_status`.
- `backend/terramedic/nominations/tests/test_evaluate_pending.py` (new) — 8 command tests.
- `backend/curation/tests/test_evaluate.py` — 5 new helper tests.

## Tests

552 pass across the project. New coverage:

**`TestEvaluateOrgViaClaudeCode`** (5): CLI invoked with expected flags, extracts `result` from envelope, stamps `claude-code:` prefix, raises on `is_error`, raises on non-zero exit.

**`TestClaimNominations` additions** (4): default `QUEUED` still ignores `PENDING`, `from_status=PENDING` claims only `PENDING`, transitions to `EVALUATING`, reverts to `PENDING` on skip.

**`TestEvaluatePending`** (6) + **`TestSkipBehavior`** (2): processes `PENDING` → `EVALUATED`, leaves `QUEUED` untouched, links evaluation to nomination, on failure marks `FAILED`, passes categories through, respects `--limit`, existing-Organization URL not evaluated, mixed batch skips only duplicates.

## Test plan

- [x] 552 tests pass
- [ ] Log into Claude Code (`claude auth`) on the laptop
- [ ] Create a couple of PENDING nominations in dev
- [ ] Run `SECRET_KEY=... DEBUG=true poetry run python manage.py evaluate_pending --limit 2`
- [ ] Verify skip report appears if any URL is a duplicate
- [ ] Verify `OrganizationEvaluation` rows created with `evaluated_by` starting `claude-code:`
- [ ] Verify Max quota consumed (not API credits)

## Notes

- Depends on PR #212's cost optimizations only at the conceptual level; merges cleanly either order (PR #212 touches the API path, this one touches the local path).
- This command is only viable on a machine with an interactive `claude auth` login. Not deployable to Lambda / CI runners.