### PR TITLE
feat(routes): convert org listings to streaming SSR

### DIFF
--- a/terramedic/e2e/other-actions.test.ts
+++ b/terramedic/e2e/other-actions.test.ts
@@ -11,5 +11,9 @@ test.describe('Other Actions page', () => {
     await page.goto('/other-actions');
     const grid = page.locator('[data-testid="org-card-grid"]');
     await expect(grid).toBeAttached();
+    // Streaming SSR should reach a terminal state — grid, empty
+    // message, or error. The skeleton's aria-busy region must be
+    // gone; otherwise the page is stuck loading.
+    await expect(grid.locator('[aria-busy="true"]')).toHaveCount(0);
   });
 });

--- a/terramedic/src/lib/components/OrganizationGrid.svelte
+++ b/terramedic/src/lib/components/OrganizationGrid.svelte
@@ -1,0 +1,46 @@
+<script>
+  import OrganizationCard from '$lib/components/OrganizationCard.svelte';
+  import OrganizationGridSkeleton from '$lib/components/OrganizationGridSkeleton.svelte';
+  import { trackSectionView } from '$lib/utils/analytics';
+
+  // Shared wrapper for listing pages (/volunteer, /donate, etc.) that
+  // stream an organization list via {#await}. Handles skeleton / empty
+  // / error states and attaches analytics to a wrapper that's present
+  // in every branch so section_view fires regardless of outcome.
+  export let promise;
+  export let gridClass;
+  export let tagColor;
+  export let buttonColor;
+  export let emptyText;
+  export let analyticsSection;
+  export let analyticsPage;
+</script>
+
+<div use:trackSectionView={{ section: analyticsSection, page: analyticsPage }}>
+  {#await promise}
+    <OrganizationGridSkeleton {gridClass} />
+  {:then organizations}
+    {#if organizations.length === 0}
+      <p class="text-center text-gray-400">{emptyText}</p>
+    {:else}
+      <div class={gridClass}>
+        {#each organizations as org (org.id)}
+          <OrganizationCard
+            name={org.name}
+            description={org.description}
+            websiteUrl={org.website_url}
+            imageUrl={org.image_url}
+            tags={org.tags}
+            {tagColor}
+            {buttonColor}
+            actionText={org.action_text}
+          />
+        {/each}
+      </div>
+    {/if}
+  {:catch}
+    <p class="text-center text-red-400">
+      Couldn't load organizations. Please refresh to try again.
+    </p>
+  {/await}
+</div>

--- a/terramedic/src/lib/components/OrganizationGrid.svelte.test.ts
+++ b/terramedic/src/lib/components/OrganizationGrid.svelte.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+import OrganizationGrid from './OrganizationGrid.svelte';
+import type { Organization } from '$lib/server/api';
+
+const baseProps = {
+  gridClass: 'grid gap-6 md:grid-cols-2',
+  tagColor: 'blue',
+  buttonColor: 'blue',
+  emptyText: 'No organizations yet.',
+  analyticsSection: 'organizations',
+  analyticsPage: 'test'
+};
+
+function makeOrg(overrides: Partial<Organization> = {}): Organization {
+  return {
+    id: 1,
+    name: 'Test Org',
+    description: 'A test organization',
+    action_text: 'Visit',
+    website_url: 'https://example.org',
+    image_url: '',
+    categories: ['volunteer'],
+    tags: ['climate'],
+    sort_order: 0,
+    ...overrides
+  };
+}
+
+describe('OrganizationGrid', () => {
+  test('renders skeleton while the promise is pending', () => {
+    const pending = new Promise<Organization[]>(() => {
+      // never resolves
+    });
+    const { container } = render(OrganizationGrid, {
+      props: { ...baseProps, promise: pending }
+    });
+    expect(screen.getByLabelText('Loading organizations')).toBeInTheDocument();
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+  });
+
+  test('shows empty-text when the promise resolves to an empty array', async () => {
+    const promise = Promise.resolve<Organization[]>([]);
+    render(OrganizationGrid, { props: { ...baseProps, promise } });
+
+    await waitFor(() => {
+      expect(screen.getByText('No organizations yet.')).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText('Loading organizations')).not.toBeInTheDocument();
+  });
+
+  test('renders cards when the promise resolves with organizations', async () => {
+    const orgs = [makeOrg({ id: 1, name: 'First Org' }), makeOrg({ id: 2, name: 'Second Org' })];
+    const promise = Promise.resolve(orgs);
+    render(OrganizationGrid, { props: { ...baseProps, promise } });
+
+    await waitFor(() => {
+      expect(screen.getByText('First Org')).toBeInTheDocument();
+      expect(screen.getByText('Second Org')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('No organizations yet.')).not.toBeInTheDocument();
+  });
+
+  test('shows refresh-to-retry message when the promise rejects', async () => {
+    const promise = Promise.reject(new Error('API down'));
+    // Suppress the unhandled-rejection warning from the test runner.
+    promise.catch(() => undefined);
+    render(OrganizationGrid, { props: { ...baseProps, promise } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't load organizations/)).toBeInTheDocument();
+    });
+  });
+});

--- a/terramedic/src/lib/components/OrganizationGrid.svelte.test.ts
+++ b/terramedic/src/lib/components/OrganizationGrid.svelte.test.ts
@@ -36,7 +36,7 @@ describe('OrganizationGrid', () => {
     const { container } = render(OrganizationGrid, {
       props: { ...baseProps, promise: pending }
     });
-    expect(screen.getByLabelText('Loading organizations')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
     expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
   });
 
@@ -47,7 +47,7 @@ describe('OrganizationGrid', () => {
     await waitFor(() => {
       expect(screen.getByText('No organizations yet.')).toBeInTheDocument();
     });
-    expect(screen.queryByLabelText('Loading organizations')).not.toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
   test('renders cards when the promise resolves with organizations', async () => {

--- a/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
+++ b/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
@@ -1,0 +1,27 @@
+<script>
+  // Skeleton shown while the org list streams in. Mirrors the
+  // 1/2/3-column OrganizationCard grid so the layout doesn't jump.
+  export let count = 3;
+
+  $: indices = [...Array(count).keys()];
+</script>
+
+<div
+  class="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
+  aria-busy="true"
+  aria-label="Loading organizations"
+>
+  {#each indices as i (i)}
+    <div class="!bg-navy h-full animate-pulse rounded-lg border border-white/10 p-5">
+      <div class="mb-3 h-6 w-3/4 rounded bg-white/10"></div>
+      <div class="mb-3 flex flex-wrap gap-1.5">
+        <span class="inline-block h-5 w-16 rounded-full bg-white/10"></span>
+        <span class="inline-block h-5 w-20 rounded-full bg-white/10"></span>
+      </div>
+      <div class="mb-2 h-4 w-full rounded bg-white/5"></div>
+      <div class="mb-2 h-4 w-5/6 rounded bg-white/5"></div>
+      <div class="mb-5 h-4 w-2/3 rounded bg-white/5"></div>
+      <div class="mt-auto h-10 w-full rounded bg-white/10"></div>
+    </div>
+  {/each}
+</div>

--- a/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
+++ b/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
@@ -6,7 +6,9 @@
   export let count = 3;
   export let gridClass = 'grid gap-6 md:grid-cols-2 lg:grid-cols-3';
 
-  const indices = [...Array(count).keys()];
+  // Reactive so callers can pass a dynamic count prop and the grid
+  // stays in sync.
+  $: indices = [...Array(count).keys()];
 </script>
 
 <div class={gridClass} role="status" aria-live="polite" aria-busy="true">

--- a/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
+++ b/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
@@ -12,7 +12,7 @@
 <div class={gridClass} role="status" aria-live="polite" aria-busy="true">
   <span class="sr-only">Loading organizations</span>
   {#each indices as i (i)}
-    <div class="!bg-navy h-full animate-pulse rounded-lg border border-white/10 p-5">
+    <div class="!bg-navy flex h-full animate-pulse flex-col rounded-lg border border-white/10 p-5">
       <div class="mb-3 h-6 w-3/4 rounded bg-white/10"></div>
       <div class="mb-3 flex flex-wrap gap-1.5">
         <span class="inline-block h-5 w-16 rounded-full bg-white/10"></span>

--- a/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
+++ b/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
@@ -9,7 +9,8 @@
   $: indices = [...Array(count).keys()];
 </script>
 
-<div class={gridClass} aria-busy="true" aria-label="Loading organizations">
+<div class={gridClass} role="status" aria-live="polite" aria-busy="true">
+  <span class="sr-only">Loading organizations</span>
   {#each indices as i (i)}
     <div class="!bg-navy h-full animate-pulse rounded-lg border border-white/10 p-5">
       <div class="mb-3 h-6 w-3/4 rounded bg-white/10"></div>

--- a/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
+++ b/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
@@ -6,7 +6,7 @@
   export let count = 3;
   export let gridClass = 'grid gap-6 md:grid-cols-2 lg:grid-cols-3';
 
-  $: indices = [...Array(count).keys()];
+  const indices = [...Array(count).keys()];
 </script>
 
 <div class={gridClass} role="status" aria-live="polite" aria-busy="true">

--- a/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
+++ b/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
@@ -1,16 +1,15 @@
 <script>
-  // Skeleton shown while the org list streams in. Mirrors the
-  // 1/2/3-column OrganizationCard grid so the layout doesn't jump.
+  // Skeleton shown while the org list streams in. The caller passes
+  // `gridClass` to match its final grid so the layout doesn't jump
+  // when the real cards render. Defaults to the 3-column layout used
+  // by volunteer/donate.
   export let count = 3;
+  export let gridClass = 'grid gap-6 md:grid-cols-2 lg:grid-cols-3';
 
   $: indices = [...Array(count).keys()];
 </script>
 
-<div
-  class="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
-  aria-busy="true"
-  aria-label="Loading organizations"
->
+<div class={gridClass} aria-busy="true" aria-label="Loading organizations">
   {#each indices as i (i)}
     <div class="!bg-navy h-full animate-pulse rounded-lg border border-white/10 p-5">
       <div class="mb-3 h-6 w-3/4 rounded bg-white/10"></div>

--- a/terramedic/src/lib/components/OrganizationGridSkeleton.svelte.test.ts
+++ b/terramedic/src/lib/components/OrganizationGridSkeleton.svelte.test.ts
@@ -31,14 +31,21 @@ describe('OrganizationGridSkeleton', () => {
     expect(root).not.toHaveClass('lg:grid-cols-3');
   });
 
-  test('sets aria-busy=true on the root for assistive tech', () => {
+  test('exposes a polite live region that announces loading', () => {
     const { container } = render(OrganizationGridSkeleton);
     const root = container.firstElementChild;
+    expect(root).toHaveAttribute('role', 'status');
+    expect(root).toHaveAttribute('aria-live', 'polite');
     expect(root).toHaveAttribute('aria-busy', 'true');
   });
 
-  test('exposes an accessible loading label', () => {
+  test('renders visually-hidden loading text for screen readers', () => {
     render(OrganizationGridSkeleton);
-    expect(screen.getByLabelText('Loading organizations')).toBeInTheDocument();
+    expect(screen.getByText('Loading organizations')).toBeInTheDocument();
+  });
+
+  test('getByRole("status") finds the loading region', () => {
+    render(OrganizationGridSkeleton);
+    expect(screen.getByRole('status')).toBeInTheDocument();
   });
 });

--- a/terramedic/src/lib/components/OrganizationGridSkeleton.svelte.test.ts
+++ b/terramedic/src/lib/components/OrganizationGridSkeleton.svelte.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/svelte';
+import OrganizationGridSkeleton from './OrganizationGridSkeleton.svelte';
+
+describe('OrganizationGridSkeleton', () => {
+  test('defaults to 3 skeleton cards', () => {
+    const { container } = render(OrganizationGridSkeleton);
+    const cards = container.querySelectorAll('.animate-pulse');
+    expect(cards).toHaveLength(3);
+  });
+
+  test('respects custom count prop', () => {
+    const { container } = render(OrganizationGridSkeleton, { props: { count: 6 } });
+    const cards = container.querySelectorAll('.animate-pulse');
+    expect(cards).toHaveLength(6);
+  });
+
+  test('applies default gridClass (3-column layout)', () => {
+    const { container } = render(OrganizationGridSkeleton);
+    const root = container.firstElementChild;
+    expect(root).toHaveClass('grid', 'gap-6', 'md:grid-cols-2', 'lg:grid-cols-3');
+  });
+
+  test('applies custom gridClass prop', () => {
+    const { container } = render(OrganizationGridSkeleton, {
+      props: { gridClass: 'grid gap-8 md:grid-cols-2' }
+    });
+    const root = container.firstElementChild;
+    expect(root).toHaveClass('grid', 'gap-8', 'md:grid-cols-2');
+    expect(root).not.toHaveClass('lg:grid-cols-3');
+  });
+
+  test('sets aria-busy=true on the root for assistive tech', () => {
+    const { container } = render(OrganizationGridSkeleton);
+    const root = container.firstElementChild;
+    expect(root).toHaveAttribute('aria-busy', 'true');
+  });
+
+  test('exposes an accessible loading label', () => {
+    render(OrganizationGridSkeleton);
+    expect(screen.getByLabelText('Loading organizations')).toBeInTheDocument();
+  });
+});

--- a/terramedic/src/lib/server/api.ts
+++ b/terramedic/src/lib/server/api.ts
@@ -33,3 +33,22 @@ export async function fetchOrganizations(
 
   return await response.json();
 }
+
+/**
+ * Build a streaming SSR `load` result that fetches organizations for
+ * the given category. The returned object contains an unresolved
+ * Promise so SvelteKit streams the list to the client while the
+ * page shell renders immediately.
+ */
+export function loadOrganizations(
+  category: string,
+  request: Request
+): { organizations: Promise<Organization[]> } {
+  const acceptLanguage = request.headers.get('accept-language') ?? undefined;
+  return {
+    organizations: fetchOrganizations(category, acceptLanguage).catch((error) => {
+      console.error(`Failed to load ${category} organizations:`, error);
+      throw error;
+    })
+  };
+}

--- a/terramedic/src/lib/server/api.ts
+++ b/terramedic/src/lib/server/api.ts
@@ -49,9 +49,13 @@ export function loadOrganizations(
     organizations: fetchOrganizations(category, acceptLanguage).catch((error) => {
       // Structured log so aggregators can pivot on category; rethrow
       // so the client's {:catch} branch renders the error message.
+      // Stack is useful in Sentry/CloudWatch for debugging production
+      // failures — drop the guard on error instanceof Error once we
+      // know fetch always throws Error subclasses.
       console.error('fetchOrganizations failed', {
         category,
-        message: error instanceof Error ? error.message : String(error)
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined
       });
       throw error;
     })

--- a/terramedic/src/lib/server/api.ts
+++ b/terramedic/src/lib/server/api.ts
@@ -47,7 +47,12 @@ export function loadOrganizations(
   const acceptLanguage = request.headers.get('accept-language') ?? undefined;
   return {
     organizations: fetchOrganizations(category, acceptLanguage).catch((error) => {
-      console.error(`Failed to load ${category} organizations:`, error);
+      // Structured log so aggregators can pivot on category; rethrow
+      // so the client's {:catch} branch renders the error message.
+      console.error('fetchOrganizations failed', {
+        category,
+        message: error instanceof Error ? error.message : String(error)
+      });
       throw error;
     })
   };

--- a/terramedic/src/routes/careers/+page.server.ts
+++ b/terramedic/src/routes/careers/+page.server.ts
@@ -1,17 +1,16 @@
 import type { PageServerLoad } from './$types';
 import { fetchOrganizations } from '$lib/server/api';
 
-export const prerender = true;
-
-export const load: PageServerLoad = async ({ request }) => {
-  // NOTE: accept-language is empty at prerender time. This is fine while
-  // content is English-only but will need revisiting when translations are added.
+export const load: PageServerLoad = ({ request }) => {
   const acceptLanguage = request.headers.get('accept-language') ?? undefined;
-  try {
-    const organizations = await fetchOrganizations('career', acceptLanguage);
-    return { organizations };
-  } catch (error) {
-    console.error('Failed to load organizations:', error);
-    return { organizations: [] };
-  }
+  // Streaming SSR: return the promise rather than awaiting so SvelteKit
+  // sends the page shell immediately and streams the org list when the
+  // API responds. The component uses {#await} to show a skeleton until
+  // the promise resolves.
+  return {
+    organizations: fetchOrganizations('career', acceptLanguage).catch((error) => {
+      console.error('Failed to load career organizations:', error);
+      throw error;
+    })
+  };
 };

--- a/terramedic/src/routes/careers/+page.server.ts
+++ b/terramedic/src/routes/careers/+page.server.ts
@@ -1,16 +1,4 @@
 import type { PageServerLoad } from './$types';
-import { fetchOrganizations } from '$lib/server/api';
+import { loadOrganizations } from '$lib/server/api';
 
-export const load: PageServerLoad = ({ request }) => {
-  const acceptLanguage = request.headers.get('accept-language') ?? undefined;
-  // Streaming SSR: return the promise rather than awaiting so SvelteKit
-  // sends the page shell immediately and streams the org list when the
-  // API responds. The component uses {#await} to show a skeleton until
-  // the promise resolves.
-  return {
-    organizations: fetchOrganizations('career', acceptLanguage).catch((error) => {
-      console.error('Failed to load career organizations:', error);
-      throw error;
-    })
-  };
-};
+export const load: PageServerLoad = ({ request }) => loadOrganizations('career', request);

--- a/terramedic/src/routes/careers/+page.svelte
+++ b/terramedic/src/routes/careers/+page.svelte
@@ -50,7 +50,7 @@
       </p>
 
       {#await data.organizations}
-        <OrganizationGridSkeleton />
+        <OrganizationGridSkeleton gridClass="grid gap-6 md:grid-cols-2" />
       {:then organizations}
         {#if organizations.length === 0}
           <p class="text-center text-gray-400">

--- a/terramedic/src/routes/careers/+page.svelte
+++ b/terramedic/src/routes/careers/+page.svelte
@@ -49,37 +49,36 @@
         hiring people who want to make a difference.
       </p>
 
-      {#await data.organizations}
-        <OrganizationGridSkeleton gridClass="grid gap-6 md:grid-cols-2" />
-      {:then organizations}
-        {#if organizations.length === 0}
-          <p class="text-center text-gray-400">
-            No environmental career boards yet — check back soon.
+      <div use:trackSectionView={{ section: 'organizations', page: 'careers' }}>
+        {#await data.organizations}
+          <OrganizationGridSkeleton gridClass="grid gap-6 md:grid-cols-2" />
+        {:then organizations}
+          {#if organizations.length === 0}
+            <p class="text-center text-gray-400">
+              No environmental career boards yet — check back soon.
+            </p>
+          {:else}
+            <div class="grid gap-6 md:grid-cols-2">
+              {#each organizations as org (org.id)}
+                <OrganizationCard
+                  name={org.name}
+                  description={org.description}
+                  websiteUrl={org.website_url}
+                  imageUrl={org.image_url}
+                  tags={org.tags}
+                  tagColor="gold"
+                  buttonColor="gold"
+                  actionText={org.action_text}
+                />
+              {/each}
+            </div>
+          {/if}
+        {:catch}
+          <p class="text-center text-red-400">
+            Couldn't load organizations. Please refresh to try again.
           </p>
-        {:else}
-          <div
-            class="grid gap-6 md:grid-cols-2"
-            use:trackSectionView={{ section: 'organizations', page: 'careers' }}
-          >
-            {#each organizations as org (org.id)}
-              <OrganizationCard
-                name={org.name}
-                description={org.description}
-                websiteUrl={org.website_url}
-                imageUrl={org.image_url}
-                tags={org.tags}
-                tagColor="gold"
-                buttonColor="gold"
-                actionText={org.action_text}
-              />
-            {/each}
-          </div>
-        {/if}
-      {:catch}
-        <p class="text-center text-red-400">
-          Couldn't load organizations. Please refresh to try again.
-        </p>
-      {/await}
+        {/await}
+      </div>
 
       <div class="mt-16 mb-6 text-center">
         <h2 class="mb-2 text-xl font-bold text-white md:text-2xl">

--- a/terramedic/src/routes/careers/+page.svelte
+++ b/terramedic/src/routes/careers/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import OrganizationCard from '$lib/components/OrganizationCard.svelte';
+  import OrganizationGridSkeleton from '$lib/components/OrganizationGridSkeleton.svelte';
   import IconCard from '$lib/components/IconCard.svelte';
   import NavBar from '$lib/components/NavBar.svelte';
   import Footer from '$lib/components/Footer.svelte';
@@ -48,23 +49,37 @@
         hiring people who want to make a difference.
       </p>
 
-      <div
-        class="grid gap-6 md:grid-cols-2"
-        use:trackSectionView={{ section: 'organizations', page: 'careers' }}
-      >
-        {#each data.organizations as org (org.id)}
-          <OrganizationCard
-            name={org.name}
-            description={org.description}
-            websiteUrl={org.website_url}
-            imageUrl={org.image_url}
-            tags={org.tags}
-            tagColor="gold"
-            buttonColor="gold"
-            actionText={org.action_text}
-          />
-        {/each}
-      </div>
+      {#await data.organizations}
+        <OrganizationGridSkeleton />
+      {:then organizations}
+        {#if organizations.length === 0}
+          <p class="text-center text-gray-400">
+            No environmental career boards yet — check back soon.
+          </p>
+        {:else}
+          <div
+            class="grid gap-6 md:grid-cols-2"
+            use:trackSectionView={{ section: 'organizations', page: 'careers' }}
+          >
+            {#each organizations as org (org.id)}
+              <OrganizationCard
+                name={org.name}
+                description={org.description}
+                websiteUrl={org.website_url}
+                imageUrl={org.image_url}
+                tags={org.tags}
+                tagColor="gold"
+                buttonColor="gold"
+                actionText={org.action_text}
+              />
+            {/each}
+          </div>
+        {/if}
+      {:catch}
+        <p class="text-center text-red-400">
+          Couldn't load organizations. Please refresh to try again.
+        </p>
+      {/await}
 
       <div class="mt-16 mb-6 text-center">
         <h2 class="mb-2 text-xl font-bold text-white md:text-2xl">

--- a/terramedic/src/routes/careers/+page.svelte
+++ b/terramedic/src/routes/careers/+page.svelte
@@ -1,6 +1,5 @@
 <script>
-  import OrganizationCard from '$lib/components/OrganizationCard.svelte';
-  import OrganizationGridSkeleton from '$lib/components/OrganizationGridSkeleton.svelte';
+  import OrganizationGrid from '$lib/components/OrganizationGrid.svelte';
   import IconCard from '$lib/components/IconCard.svelte';
   import NavBar from '$lib/components/NavBar.svelte';
   import Footer from '$lib/components/Footer.svelte';
@@ -49,36 +48,15 @@
         hiring people who want to make a difference.
       </p>
 
-      <div use:trackSectionView={{ section: 'organizations', page: 'careers' }}>
-        {#await data.organizations}
-          <OrganizationGridSkeleton gridClass="grid gap-6 md:grid-cols-2" />
-        {:then organizations}
-          {#if organizations.length === 0}
-            <p class="text-center text-gray-400">
-              No environmental career boards yet — check back soon.
-            </p>
-          {:else}
-            <div class="grid gap-6 md:grid-cols-2">
-              {#each organizations as org (org.id)}
-                <OrganizationCard
-                  name={org.name}
-                  description={org.description}
-                  websiteUrl={org.website_url}
-                  imageUrl={org.image_url}
-                  tags={org.tags}
-                  tagColor="gold"
-                  buttonColor="gold"
-                  actionText={org.action_text}
-                />
-              {/each}
-            </div>
-          {/if}
-        {:catch}
-          <p class="text-center text-red-400">
-            Couldn't load organizations. Please refresh to try again.
-          </p>
-        {/await}
-      </div>
+      <OrganizationGrid
+        promise={data.organizations}
+        gridClass="grid gap-6 md:grid-cols-2"
+        tagColor="gold"
+        buttonColor="gold"
+        emptyText="No environmental career boards yet — check back soon."
+        analyticsSection="organizations"
+        analyticsPage="careers"
+      />
 
       <div class="mt-16 mb-6 text-center">
         <h2 class="mb-2 text-xl font-bold text-white md:text-2xl">

--- a/terramedic/src/routes/donate/+page.server.ts
+++ b/terramedic/src/routes/donate/+page.server.ts
@@ -1,16 +1,4 @@
 import type { PageServerLoad } from './$types';
-import { fetchOrganizations } from '$lib/server/api';
+import { loadOrganizations } from '$lib/server/api';
 
-export const load: PageServerLoad = ({ request }) => {
-  const acceptLanguage = request.headers.get('accept-language') ?? undefined;
-  // Streaming SSR: return the promise rather than awaiting so SvelteKit
-  // sends the page shell immediately and streams the org list when the
-  // API responds. The component uses {#await} to show a skeleton until
-  // the promise resolves.
-  return {
-    organizations: fetchOrganizations('donate', acceptLanguage).catch((error) => {
-      console.error('Failed to load donate organizations:', error);
-      throw error;
-    })
-  };
-};
+export const load: PageServerLoad = ({ request }) => loadOrganizations('donate', request);

--- a/terramedic/src/routes/donate/+page.server.ts
+++ b/terramedic/src/routes/donate/+page.server.ts
@@ -1,17 +1,16 @@
 import type { PageServerLoad } from './$types';
 import { fetchOrganizations } from '$lib/server/api';
 
-export const prerender = true;
-
-export const load: PageServerLoad = async ({ request }) => {
-  // NOTE: accept-language is empty at prerender time. This is fine while
-  // content is English-only but will need revisiting when translations are added.
+export const load: PageServerLoad = ({ request }) => {
   const acceptLanguage = request.headers.get('accept-language') ?? undefined;
-  try {
-    const organizations = await fetchOrganizations('donate', acceptLanguage);
-    return { organizations };
-  } catch (error) {
-    console.error('Failed to load organizations:', error);
-    return { organizations: [] };
-  }
+  // Streaming SSR: return the promise rather than awaiting so SvelteKit
+  // sends the page shell immediately and streams the org list when the
+  // API responds. The component uses {#await} to show a skeleton until
+  // the promise resolves.
+  return {
+    organizations: fetchOrganizations('donate', acceptLanguage).catch((error) => {
+      console.error('Failed to load donate organizations:', error);
+      throw error;
+    })
+  };
 };

--- a/terramedic/src/routes/donate/+page.svelte
+++ b/terramedic/src/routes/donate/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import OrganizationCard from '$lib/components/OrganizationCard.svelte';
+  import OrganizationGridSkeleton from '$lib/components/OrganizationGridSkeleton.svelte';
   import IconCard from '$lib/components/IconCard.svelte';
   import NavBar from '$lib/components/NavBar.svelte';
   import Footer from '$lib/components/Footer.svelte';
@@ -49,23 +50,35 @@
         can help.
       </p>
 
-      <div
-        class="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
-        use:trackSectionView={{ section: 'organizations', page: 'donate' }}
-      >
-        {#each data.organizations as org (org.id)}
-          <OrganizationCard
-            name={org.name}
-            description={org.description}
-            websiteUrl={org.website_url}
-            imageUrl={org.image_url}
-            tags={org.tags}
-            tagColor="green"
-            buttonColor="green"
-            actionText={org.action_text}
-          />
-        {/each}
-      </div>
+      {#await data.organizations}
+        <OrganizationGridSkeleton />
+      {:then organizations}
+        {#if organizations.length === 0}
+          <p class="text-center text-gray-400">No donation opportunities yet — check back soon.</p>
+        {:else}
+          <div
+            class="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
+            use:trackSectionView={{ section: 'organizations', page: 'donate' }}
+          >
+            {#each organizations as org (org.id)}
+              <OrganizationCard
+                name={org.name}
+                description={org.description}
+                websiteUrl={org.website_url}
+                imageUrl={org.image_url}
+                tags={org.tags}
+                tagColor="green"
+                buttonColor="green"
+                actionText={org.action_text}
+              />
+            {/each}
+          </div>
+        {/if}
+      {:catch}
+        <p class="text-center text-red-400">
+          Couldn't load organizations. Please refresh to try again.
+        </p>
+      {/await}
 
       <div class="mt-16 mb-6 text-center">
         <h2 class="mb-2 text-xl font-bold text-white md:text-2xl">Maximizing Your Impact</h2>

--- a/terramedic/src/routes/donate/+page.svelte
+++ b/terramedic/src/routes/donate/+page.svelte
@@ -50,35 +50,36 @@
         can help.
       </p>
 
-      {#await data.organizations}
-        <OrganizationGridSkeleton />
-      {:then organizations}
-        {#if organizations.length === 0}
-          <p class="text-center text-gray-400">No donation opportunities yet — check back soon.</p>
-        {:else}
-          <div
-            class="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
-            use:trackSectionView={{ section: 'organizations', page: 'donate' }}
-          >
-            {#each organizations as org (org.id)}
-              <OrganizationCard
-                name={org.name}
-                description={org.description}
-                websiteUrl={org.website_url}
-                imageUrl={org.image_url}
-                tags={org.tags}
-                tagColor="green"
-                buttonColor="green"
-                actionText={org.action_text}
-              />
-            {/each}
-          </div>
-        {/if}
-      {:catch}
-        <p class="text-center text-red-400">
-          Couldn't load organizations. Please refresh to try again.
-        </p>
-      {/await}
+      <div use:trackSectionView={{ section: 'organizations', page: 'donate' }}>
+        {#await data.organizations}
+          <OrganizationGridSkeleton />
+        {:then organizations}
+          {#if organizations.length === 0}
+            <p class="text-center text-gray-400">
+              No donation opportunities yet — check back soon.
+            </p>
+          {:else}
+            <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {#each organizations as org (org.id)}
+                <OrganizationCard
+                  name={org.name}
+                  description={org.description}
+                  websiteUrl={org.website_url}
+                  imageUrl={org.image_url}
+                  tags={org.tags}
+                  tagColor="green"
+                  buttonColor="green"
+                  actionText={org.action_text}
+                />
+              {/each}
+            </div>
+          {/if}
+        {:catch}
+          <p class="text-center text-red-400">
+            Couldn't load organizations. Please refresh to try again.
+          </p>
+        {/await}
+      </div>
 
       <div class="mt-16 mb-6 text-center">
         <h2 class="mb-2 text-xl font-bold text-white md:text-2xl">Maximizing Your Impact</h2>

--- a/terramedic/src/routes/donate/+page.svelte
+++ b/terramedic/src/routes/donate/+page.svelte
@@ -1,6 +1,5 @@
 <script>
-  import OrganizationCard from '$lib/components/OrganizationCard.svelte';
-  import OrganizationGridSkeleton from '$lib/components/OrganizationGridSkeleton.svelte';
+  import OrganizationGrid from '$lib/components/OrganizationGrid.svelte';
   import IconCard from '$lib/components/IconCard.svelte';
   import NavBar from '$lib/components/NavBar.svelte';
   import Footer from '$lib/components/Footer.svelte';
@@ -50,36 +49,15 @@
         can help.
       </p>
 
-      <div use:trackSectionView={{ section: 'organizations', page: 'donate' }}>
-        {#await data.organizations}
-          <OrganizationGridSkeleton />
-        {:then organizations}
-          {#if organizations.length === 0}
-            <p class="text-center text-gray-400">
-              No donation opportunities yet — check back soon.
-            </p>
-          {:else}
-            <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-              {#each organizations as org (org.id)}
-                <OrganizationCard
-                  name={org.name}
-                  description={org.description}
-                  websiteUrl={org.website_url}
-                  imageUrl={org.image_url}
-                  tags={org.tags}
-                  tagColor="green"
-                  buttonColor="green"
-                  actionText={org.action_text}
-                />
-              {/each}
-            </div>
-          {/if}
-        {:catch}
-          <p class="text-center text-red-400">
-            Couldn't load organizations. Please refresh to try again.
-          </p>
-        {/await}
-      </div>
+      <OrganizationGrid
+        promise={data.organizations}
+        gridClass="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
+        tagColor="green"
+        buttonColor="green"
+        emptyText="No donation opportunities yet — check back soon."
+        analyticsSection="organizations"
+        analyticsPage="donate"
+      />
 
       <div class="mt-16 mb-6 text-center">
         <h2 class="mb-2 text-xl font-bold text-white md:text-2xl">Maximizing Your Impact</h2>

--- a/terramedic/src/routes/other-actions/+page.server.ts
+++ b/terramedic/src/routes/other-actions/+page.server.ts
@@ -1,16 +1,4 @@
 import type { PageServerLoad } from './$types';
-import { fetchOrganizations } from '$lib/server/api';
+import { loadOrganizations } from '$lib/server/api';
 
-export const load: PageServerLoad = ({ request }) => {
-  const acceptLanguage = request.headers.get('accept-language') ?? undefined;
-  // Streaming SSR: return the promise rather than awaiting so SvelteKit
-  // sends the page shell immediately and streams the org list when the
-  // API responds. The component uses {#await} to show a skeleton until
-  // the promise resolves.
-  return {
-    organizations: fetchOrganizations('everyday', acceptLanguage).catch((error) => {
-      console.error('Failed to load everyday organizations:', error);
-      throw error;
-    })
-  };
-};
+export const load: PageServerLoad = ({ request }) => loadOrganizations('everyday', request);

--- a/terramedic/src/routes/other-actions/+page.server.ts
+++ b/terramedic/src/routes/other-actions/+page.server.ts
@@ -1,17 +1,16 @@
 import type { PageServerLoad } from './$types';
 import { fetchOrganizations } from '$lib/server/api';
 
-export const prerender = true;
-
-export const load: PageServerLoad = async ({ request }) => {
-  // NOTE: accept-language is empty at prerender time. This is fine while
-  // content is English-only but will need revisiting when translations are added.
+export const load: PageServerLoad = ({ request }) => {
   const acceptLanguage = request.headers.get('accept-language') ?? undefined;
-  try {
-    const organizations = await fetchOrganizations('everyday', acceptLanguage);
-    return { organizations };
-  } catch (error) {
-    console.error('Failed to load organizations:', error);
-    return { organizations: [] };
-  }
+  // Streaming SSR: return the promise rather than awaiting so SvelteKit
+  // sends the page shell immediately and streams the org list when the
+  // API responds. The component uses {#await} to show a skeleton until
+  // the promise resolves.
+  return {
+    organizations: fetchOrganizations('everyday', acceptLanguage).catch((error) => {
+      console.error('Failed to load everyday organizations:', error);
+      throw error;
+    })
+  };
 };

--- a/terramedic/src/routes/other-actions/+page.svelte
+++ b/terramedic/src/routes/other-actions/+page.svelte
@@ -1,6 +1,5 @@
 <script>
-  import OrganizationCard from '$lib/components/OrganizationCard.svelte';
-  import OrganizationGridSkeleton from '$lib/components/OrganizationGridSkeleton.svelte';
+  import OrganizationGrid from '$lib/components/OrganizationGrid.svelte';
   import IconCard from '$lib/components/IconCard.svelte';
   import ActionButton from '$lib/components/ActionButton.svelte';
   import NavBar from '$lib/components/NavBar.svelte';
@@ -51,39 +50,16 @@
         can contribute to healing the planet.
       </p>
 
-      <div
-        class="mb-16"
-        data-testid="org-card-grid"
-        use:trackSectionView={{ section: 'organizations', page: 'other-actions' }}
-      >
-        {#await data.organizations}
-          <OrganizationGridSkeleton gridClass="grid gap-6 md:grid-cols-2" />
-        {:then organizations}
-          {#if organizations.length === 0}
-            <p class="text-center text-gray-400">
-              No everyday-action organizations yet — check back soon.
-            </p>
-          {:else}
-            <div class="grid gap-6 md:grid-cols-2">
-              {#each organizations as org (org.id)}
-                <OrganizationCard
-                  name={org.name}
-                  description={org.description}
-                  websiteUrl={org.website_url}
-                  imageUrl={org.image_url}
-                  tags={org.tags}
-                  tagColor="purple"
-                  buttonColor="purple"
-                  actionText={org.action_text}
-                />
-              {/each}
-            </div>
-          {/if}
-        {:catch}
-          <p class="text-center text-red-400">
-            Couldn't load organizations. Please refresh to try again.
-          </p>
-        {/await}
+      <div class="mb-16" data-testid="org-card-grid">
+        <OrganizationGrid
+          promise={data.organizations}
+          gridClass="grid gap-6 md:grid-cols-2"
+          tagColor="purple"
+          buttonColor="purple"
+          emptyText="No everyday-action organizations yet — check back soon."
+          analyticsSection="organizations"
+          analyticsPage="other-actions"
+        />
       </div>
 
       <div class="mb-6 text-center">

--- a/terramedic/src/routes/other-actions/+page.svelte
+++ b/terramedic/src/routes/other-actions/+page.svelte
@@ -51,7 +51,11 @@
         can contribute to healing the planet.
       </p>
 
-      <div class="mb-16" data-testid="org-card-grid">
+      <div
+        class="mb-16"
+        data-testid="org-card-grid"
+        use:trackSectionView={{ section: 'organizations', page: 'other-actions' }}
+      >
         {#await data.organizations}
           <OrganizationGridSkeleton gridClass="grid gap-6 md:grid-cols-2" />
         {:then organizations}
@@ -60,10 +64,7 @@
               No everyday-action organizations yet — check back soon.
             </p>
           {:else}
-            <div
-              class="grid gap-6 md:grid-cols-2"
-              use:trackSectionView={{ section: 'organizations', page: 'other-actions' }}
-            >
+            <div class="grid gap-6 md:grid-cols-2">
               {#each organizations as org (org.id)}
                 <OrganizationCard
                   name={org.name}

--- a/terramedic/src/routes/other-actions/+page.svelte
+++ b/terramedic/src/routes/other-actions/+page.svelte
@@ -51,7 +51,7 @@
         can contribute to healing the planet.
       </p>
 
-      <div class="mb-16">
+      <div class="mb-16" data-testid="org-card-grid">
         {#await data.organizations}
           <OrganizationGridSkeleton />
         {:then organizations}
@@ -61,7 +61,6 @@
             </p>
           {:else}
             <div
-              data-testid="org-card-grid"
               class="grid gap-6 md:grid-cols-2"
               use:trackSectionView={{ section: 'organizations', page: 'other-actions' }}
             >

--- a/terramedic/src/routes/other-actions/+page.svelte
+++ b/terramedic/src/routes/other-actions/+page.svelte
@@ -53,7 +53,7 @@
 
       <div class="mb-16" data-testid="org-card-grid">
         {#await data.organizations}
-          <OrganizationGridSkeleton />
+          <OrganizationGridSkeleton gridClass="grid gap-6 md:grid-cols-2" />
         {:then organizations}
           {#if organizations.length === 0}
             <p class="text-center text-gray-400">

--- a/terramedic/src/routes/other-actions/+page.svelte
+++ b/terramedic/src/routes/other-actions/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import OrganizationCard from '$lib/components/OrganizationCard.svelte';
+  import OrganizationGridSkeleton from '$lib/components/OrganizationGridSkeleton.svelte';
   import IconCard from '$lib/components/IconCard.svelte';
   import ActionButton from '$lib/components/ActionButton.svelte';
   import NavBar from '$lib/components/NavBar.svelte';
@@ -50,23 +51,39 @@
         can contribute to healing the planet.
       </p>
 
-      <div
-        data-testid="org-card-grid"
-        class="mb-16 grid gap-6 md:grid-cols-2"
-        use:trackSectionView={{ section: 'organizations', page: 'other-actions' }}
-      >
-        {#each data.organizations as org (org.id)}
-          <OrganizationCard
-            name={org.name}
-            description={org.description}
-            websiteUrl={org.website_url}
-            imageUrl={org.image_url}
-            tags={org.tags}
-            tagColor="purple"
-            buttonColor="purple"
-            actionText={org.action_text}
-          />
-        {/each}
+      <div class="mb-16">
+        {#await data.organizations}
+          <OrganizationGridSkeleton />
+        {:then organizations}
+          {#if organizations.length === 0}
+            <p class="text-center text-gray-400">
+              No everyday-action organizations yet — check back soon.
+            </p>
+          {:else}
+            <div
+              data-testid="org-card-grid"
+              class="grid gap-6 md:grid-cols-2"
+              use:trackSectionView={{ section: 'organizations', page: 'other-actions' }}
+            >
+              {#each organizations as org (org.id)}
+                <OrganizationCard
+                  name={org.name}
+                  description={org.description}
+                  websiteUrl={org.website_url}
+                  imageUrl={org.image_url}
+                  tags={org.tags}
+                  tagColor="purple"
+                  buttonColor="purple"
+                  actionText={org.action_text}
+                />
+              {/each}
+            </div>
+          {/if}
+        {:catch}
+          <p class="text-center text-red-400">
+            Couldn't load organizations. Please refresh to try again.
+          </p>
+        {/await}
       </div>
 
       <div class="mb-6 text-center">

--- a/terramedic/src/routes/resources/+page.server.ts
+++ b/terramedic/src/routes/resources/+page.server.ts
@@ -1,16 +1,4 @@
 import type { PageServerLoad } from './$types';
-import { fetchOrganizations } from '$lib/server/api';
+import { loadOrganizations } from '$lib/server/api';
 
-export const load: PageServerLoad = ({ request }) => {
-  const acceptLanguage = request.headers.get('accept-language') ?? undefined;
-  // Streaming SSR: return the promise rather than awaiting so SvelteKit
-  // sends the page shell immediately and streams the org list when the
-  // API responds. The component uses {#await} to show a skeleton until
-  // the promise resolves.
-  return {
-    organizations: fetchOrganizations('resource', acceptLanguage).catch((error) => {
-      console.error('Failed to load resource organizations:', error);
-      throw error;
-    })
-  };
-};
+export const load: PageServerLoad = ({ request }) => loadOrganizations('resource', request);

--- a/terramedic/src/routes/resources/+page.server.ts
+++ b/terramedic/src/routes/resources/+page.server.ts
@@ -1,17 +1,16 @@
 import type { PageServerLoad } from './$types';
 import { fetchOrganizations } from '$lib/server/api';
 
-export const prerender = true;
-
-export const load: PageServerLoad = async ({ request }) => {
-  // NOTE: accept-language is empty at prerender time. This is fine while
-  // content is English-only but will need revisiting when translations are added.
+export const load: PageServerLoad = ({ request }) => {
   const acceptLanguage = request.headers.get('accept-language') ?? undefined;
-  try {
-    const organizations = await fetchOrganizations('resource', acceptLanguage);
-    return { organizations };
-  } catch (error) {
-    console.error('Failed to load organizations:', error);
-    return { organizations: [] };
-  }
+  // Streaming SSR: return the promise rather than awaiting so SvelteKit
+  // sends the page shell immediately and streams the org list when the
+  // API responds. The component uses {#await} to show a skeleton until
+  // the promise resolves.
+  return {
+    organizations: fetchOrganizations('resource', acceptLanguage).catch((error) => {
+      console.error('Failed to load resource organizations:', error);
+      throw error;
+    })
+  };
 };

--- a/terramedic/src/routes/resources/+page.svelte
+++ b/terramedic/src/routes/resources/+page.svelte
@@ -1,9 +1,7 @@
 <script>
   import NavBar from '$lib/components/NavBar.svelte';
   import Footer from '$lib/components/Footer.svelte';
-  import OrganizationCard from '$lib/components/OrganizationCard.svelte';
-  import OrganizationGridSkeleton from '$lib/components/OrganizationGridSkeleton.svelte';
-  import { trackSectionView } from '$lib/utils/analytics';
+  import OrganizationGrid from '$lib/components/OrganizationGrid.svelte';
 
   export let data;
   export let form;
@@ -41,36 +39,16 @@
         Tools, research, and support for those already engaged in advocacy work.
       </p>
 
-      <div
-        class="mx-auto mb-12 max-w-4xl px-4 sm:px-6"
-        use:trackSectionView={{ section: 'organizations', page: 'resources' }}
-      >
-        {#await data.organizations}
-          <OrganizationGridSkeleton gridClass="grid gap-8 md:grid-cols-2" />
-        {:then organizations}
-          {#if organizations.length === 0}
-            <p class="text-center text-gray-400">No advocate resources yet — check back soon.</p>
-          {:else}
-            <div class="grid gap-8 md:grid-cols-2">
-              {#each organizations as org (org.id)}
-                <OrganizationCard
-                  name={org.name}
-                  description={org.description}
-                  websiteUrl={org.website_url}
-                  imageUrl={org.image_url}
-                  actionText={org.action_text}
-                  tags={org.tags}
-                  tagColor="blue"
-                  buttonColor="blue"
-                />
-              {/each}
-            </div>
-          {/if}
-        {:catch}
-          <p class="text-center text-red-400">
-            Couldn't load organizations. Please refresh to try again.
-          </p>
-        {/await}
+      <div class="mx-auto mb-12 max-w-4xl px-4 sm:px-6">
+        <OrganizationGrid
+          promise={data.organizations}
+          gridClass="grid gap-8 md:grid-cols-2"
+          tagColor="blue"
+          buttonColor="blue"
+          emptyText="No advocate resources yet — check back soon."
+          analyticsSection="organizations"
+          analyticsPage="resources"
+        />
       </div>
     </div>
   </main>

--- a/terramedic/src/routes/resources/+page.svelte
+++ b/terramedic/src/routes/resources/+page.svelte
@@ -43,7 +43,7 @@
 
       <div class="mx-auto mb-12 max-w-4xl px-4 sm:px-6">
         {#await data.organizations}
-          <OrganizationGridSkeleton />
+          <OrganizationGridSkeleton gridClass="grid gap-8 md:grid-cols-2" />
         {:then organizations}
           {#if organizations.length === 0}
             <p class="text-center text-gray-400">No advocate resources yet — check back soon.</p>

--- a/terramedic/src/routes/resources/+page.svelte
+++ b/terramedic/src/routes/resources/+page.svelte
@@ -2,6 +2,7 @@
   import NavBar from '$lib/components/NavBar.svelte';
   import Footer from '$lib/components/Footer.svelte';
   import OrganizationCard from '$lib/components/OrganizationCard.svelte';
+  import OrganizationGridSkeleton from '$lib/components/OrganizationGridSkeleton.svelte';
   import { trackSectionView } from '$lib/utils/analytics';
 
   export let data;
@@ -40,22 +41,36 @@
         Tools, research, and support for those already engaged in advocacy work.
       </p>
 
-      <div
-        class="mx-auto mb-12 grid max-w-4xl gap-8 px-4 sm:px-6 md:grid-cols-2"
-        use:trackSectionView={{ section: 'organizations', page: 'resources' }}
-      >
-        {#each data.organizations as org (org.id)}
-          <OrganizationCard
-            name={org.name}
-            description={org.description}
-            websiteUrl={org.website_url}
-            imageUrl={org.image_url}
-            actionText={org.action_text}
-            tags={org.tags}
-            tagColor="blue"
-            buttonColor="blue"
-          />
-        {/each}
+      <div class="mx-auto mb-12 max-w-4xl px-4 sm:px-6">
+        {#await data.organizations}
+          <OrganizationGridSkeleton />
+        {:then organizations}
+          {#if organizations.length === 0}
+            <p class="text-center text-gray-400">No advocate resources yet — check back soon.</p>
+          {:else}
+            <div
+              class="grid gap-8 md:grid-cols-2"
+              use:trackSectionView={{ section: 'organizations', page: 'resources' }}
+            >
+              {#each organizations as org (org.id)}
+                <OrganizationCard
+                  name={org.name}
+                  description={org.description}
+                  websiteUrl={org.website_url}
+                  imageUrl={org.image_url}
+                  actionText={org.action_text}
+                  tags={org.tags}
+                  tagColor="blue"
+                  buttonColor="blue"
+                />
+              {/each}
+            </div>
+          {/if}
+        {:catch}
+          <p class="text-center text-red-400">
+            Couldn't load organizations. Please refresh to try again.
+          </p>
+        {/await}
       </div>
     </div>
   </main>

--- a/terramedic/src/routes/resources/+page.svelte
+++ b/terramedic/src/routes/resources/+page.svelte
@@ -41,17 +41,17 @@
         Tools, research, and support for those already engaged in advocacy work.
       </p>
 
-      <div class="mx-auto mb-12 max-w-4xl px-4 sm:px-6">
+      <div
+        class="mx-auto mb-12 max-w-4xl px-4 sm:px-6"
+        use:trackSectionView={{ section: 'organizations', page: 'resources' }}
+      >
         {#await data.organizations}
           <OrganizationGridSkeleton gridClass="grid gap-8 md:grid-cols-2" />
         {:then organizations}
           {#if organizations.length === 0}
             <p class="text-center text-gray-400">No advocate resources yet — check back soon.</p>
           {:else}
-            <div
-              class="grid gap-8 md:grid-cols-2"
-              use:trackSectionView={{ section: 'organizations', page: 'resources' }}
-            >
+            <div class="grid gap-8 md:grid-cols-2">
               {#each organizations as org (org.id)}
                 <OrganizationCard
                   name={org.name}

--- a/terramedic/src/routes/volunteer/+page.server.ts
+++ b/terramedic/src/routes/volunteer/+page.server.ts
@@ -1,17 +1,16 @@
 import type { PageServerLoad } from './$types';
 import { fetchOrganizations } from '$lib/server/api';
 
-export const prerender = true;
-
-export const load: PageServerLoad = async ({ request }) => {
-  // NOTE: accept-language is empty at prerender time. This is fine while
-  // content is English-only but will need revisiting when translations are added.
+export const load: PageServerLoad = ({ request }) => {
   const acceptLanguage = request.headers.get('accept-language') ?? undefined;
-  try {
-    const organizations = await fetchOrganizations('volunteer', acceptLanguage);
-    return { organizations };
-  } catch (error) {
-    console.error('Failed to load organizations:', error);
-    return { organizations: [] };
-  }
+  // Streaming SSR: return the promise rather than awaiting so SvelteKit
+  // sends the page shell immediately and streams the org list when the
+  // API responds. The component uses {#await} to show a skeleton until
+  // the promise resolves.
+  return {
+    organizations: fetchOrganizations('volunteer', acceptLanguage).catch((error) => {
+      console.error('Failed to load volunteer organizations:', error);
+      throw error;
+    })
+  };
 };

--- a/terramedic/src/routes/volunteer/+page.server.ts
+++ b/terramedic/src/routes/volunteer/+page.server.ts
@@ -1,16 +1,4 @@
 import type { PageServerLoad } from './$types';
-import { fetchOrganizations } from '$lib/server/api';
+import { loadOrganizations } from '$lib/server/api';
 
-export const load: PageServerLoad = ({ request }) => {
-  const acceptLanguage = request.headers.get('accept-language') ?? undefined;
-  // Streaming SSR: return the promise rather than awaiting so SvelteKit
-  // sends the page shell immediately and streams the org list when the
-  // API responds. The component uses {#await} to show a skeleton until
-  // the promise resolves.
-  return {
-    organizations: fetchOrganizations('volunteer', acceptLanguage).catch((error) => {
-      console.error('Failed to load volunteer organizations:', error);
-      throw error;
-    })
-  };
-};
+export const load: PageServerLoad = ({ request }) => loadOrganizations('volunteer', request);

--- a/terramedic/src/routes/volunteer/+page.svelte
+++ b/terramedic/src/routes/volunteer/+page.svelte
@@ -1,5 +1,6 @@
 <script>
   import OrganizationCard from '$lib/components/OrganizationCard.svelte';
+  import OrganizationGridSkeleton from '$lib/components/OrganizationGridSkeleton.svelte';
   import IconCard from '$lib/components/IconCard.svelte';
   import NavBar from '$lib/components/NavBar.svelte';
   import Footer from '$lib/components/Footer.svelte';
@@ -48,23 +49,35 @@
         can help build a healthier planet.
       </p>
 
-      <div
-        class="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
-        use:trackSectionView={{ section: 'organizations', page: 'volunteer' }}
-      >
-        {#each data.organizations as org (org.id)}
-          <OrganizationCard
-            name={org.name}
-            description={org.description}
-            websiteUrl={org.website_url}
-            imageUrl={org.image_url}
-            tags={org.tags}
-            tagColor="blue"
-            buttonColor="blue"
-            actionText={org.action_text}
-          />
-        {/each}
-      </div>
+      {#await data.organizations}
+        <OrganizationGridSkeleton />
+      {:then organizations}
+        {#if organizations.length === 0}
+          <p class="text-center text-gray-400">No volunteer organizations yet — check back soon.</p>
+        {:else}
+          <div
+            class="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
+            use:trackSectionView={{ section: 'organizations', page: 'volunteer' }}
+          >
+            {#each organizations as org (org.id)}
+              <OrganizationCard
+                name={org.name}
+                description={org.description}
+                websiteUrl={org.website_url}
+                imageUrl={org.image_url}
+                tags={org.tags}
+                tagColor="blue"
+                buttonColor="blue"
+                actionText={org.action_text}
+              />
+            {/each}
+          </div>
+        {/if}
+      {:catch}
+        <p class="text-center text-red-400">
+          Couldn't load organizations. Please refresh to try again.
+        </p>
+      {/await}
 
       <div class="mt-16 mb-6 text-center">
         <h2 class="mb-2 text-xl font-bold text-white md:text-2xl">Why Volunteer?</h2>

--- a/terramedic/src/routes/volunteer/+page.svelte
+++ b/terramedic/src/routes/volunteer/+page.svelte
@@ -49,35 +49,36 @@
         can help build a healthier planet.
       </p>
 
-      {#await data.organizations}
-        <OrganizationGridSkeleton />
-      {:then organizations}
-        {#if organizations.length === 0}
-          <p class="text-center text-gray-400">No volunteer organizations yet — check back soon.</p>
-        {:else}
-          <div
-            class="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
-            use:trackSectionView={{ section: 'organizations', page: 'volunteer' }}
-          >
-            {#each organizations as org (org.id)}
-              <OrganizationCard
-                name={org.name}
-                description={org.description}
-                websiteUrl={org.website_url}
-                imageUrl={org.image_url}
-                tags={org.tags}
-                tagColor="blue"
-                buttonColor="blue"
-                actionText={org.action_text}
-              />
-            {/each}
-          </div>
-        {/if}
-      {:catch}
-        <p class="text-center text-red-400">
-          Couldn't load organizations. Please refresh to try again.
-        </p>
-      {/await}
+      <div use:trackSectionView={{ section: 'organizations', page: 'volunteer' }}>
+        {#await data.organizations}
+          <OrganizationGridSkeleton />
+        {:then organizations}
+          {#if organizations.length === 0}
+            <p class="text-center text-gray-400">
+              No volunteer organizations yet — check back soon.
+            </p>
+          {:else}
+            <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {#each organizations as org (org.id)}
+                <OrganizationCard
+                  name={org.name}
+                  description={org.description}
+                  websiteUrl={org.website_url}
+                  imageUrl={org.image_url}
+                  tags={org.tags}
+                  tagColor="blue"
+                  buttonColor="blue"
+                  actionText={org.action_text}
+                />
+              {/each}
+            </div>
+          {/if}
+        {:catch}
+          <p class="text-center text-red-400">
+            Couldn't load organizations. Please refresh to try again.
+          </p>
+        {/await}
+      </div>
 
       <div class="mt-16 mb-6 text-center">
         <h2 class="mb-2 text-xl font-bold text-white md:text-2xl">Why Volunteer?</h2>

--- a/terramedic/src/routes/volunteer/+page.svelte
+++ b/terramedic/src/routes/volunteer/+page.svelte
@@ -1,6 +1,5 @@
 <script>
-  import OrganizationCard from '$lib/components/OrganizationCard.svelte';
-  import OrganizationGridSkeleton from '$lib/components/OrganizationGridSkeleton.svelte';
+  import OrganizationGrid from '$lib/components/OrganizationGrid.svelte';
   import IconCard from '$lib/components/IconCard.svelte';
   import NavBar from '$lib/components/NavBar.svelte';
   import Footer from '$lib/components/Footer.svelte';
@@ -49,36 +48,15 @@
         can help build a healthier planet.
       </p>
 
-      <div use:trackSectionView={{ section: 'organizations', page: 'volunteer' }}>
-        {#await data.organizations}
-          <OrganizationGridSkeleton />
-        {:then organizations}
-          {#if organizations.length === 0}
-            <p class="text-center text-gray-400">
-              No volunteer organizations yet — check back soon.
-            </p>
-          {:else}
-            <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-              {#each organizations as org (org.id)}
-                <OrganizationCard
-                  name={org.name}
-                  description={org.description}
-                  websiteUrl={org.website_url}
-                  imageUrl={org.image_url}
-                  tags={org.tags}
-                  tagColor="blue"
-                  buttonColor="blue"
-                  actionText={org.action_text}
-                />
-              {/each}
-            </div>
-          {/if}
-        {:catch}
-          <p class="text-center text-red-400">
-            Couldn't load organizations. Please refresh to try again.
-          </p>
-        {/await}
-      </div>
+      <OrganizationGrid
+        promise={data.organizations}
+        gridClass="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
+        tagColor="blue"
+        buttonColor="blue"
+        emptyText="No volunteer organizations yet — check back soon."
+        analyticsSection="organizations"
+        analyticsPage="volunteer"
+      />
 
       <div class="mt-16 mb-6 text-center">
         <h2 class="mb-2 text-xl font-bold text-white md:text-2xl">Why Volunteer?</h2>


### PR DESCRIPTION
## Summary

Newly-approved orgs weren't appearing on `/volunteer` (and `/donate`, `/other-actions`, `/resources`, `/careers`) without a full frontend rebuild — every listing page had `export const prerender = true`, which baked the API response at build time.

Switch all 5 listing pages to **streaming SSR**: server sends the page shell immediately, skeleton renders while the org list streams in, list replaces the skeleton when the API responds.

## Why streaming SSR vs alternatives

| | Prerender | Await SSR | Streaming SSR (this PR) | Client fetch |
|---|---|---|---|---|
| Fresh data on every request | ❌ | ✅ | ✅ | ✅ |
| First paint blocked on API | — (build-time) | ❌ (server waits) | ✅ (shell first) | ✅ (shell first) |
| SEO / first-paint-with-content | ✅ (stale) | ✅ | ✅ | ❌ (JS needed) |
| Preloader visible | — | ❌ | ✅ | ✅ |

## What's in the change

**1. `+page.server.ts` (×5)** — drop `prerender = true`, return the `fetchOrganizations()` promise unawaited. `.catch` still logs server-side and rethrows so the component's `{:catch}` branch can render.

**2. `+page.svelte` (×5)** — grid wrapped in three-branch `{#await}`:

- `{#await ...}` → `<OrganizationGridSkeleton />` (animated-pulse placeholder mirroring the card layout)
- `{:then organizations}` → the existing card grid, or a *"No X organizations yet"* empty state
- `{:catch}` → *"Couldn't load organizations. Please refresh to try again."*

**3. `OrganizationGridSkeleton.svelte` (new)** — pulse-animated skeleton that mirrors the `OrganizationCard` layout (grid shape configurable via `gridClass` prop). Marked as a polite live region (`role="status"` + `aria-live="polite"` + `aria-busy="true"`) with a visually-hidden `<span class="sr-only">Loading organizations</span>` so screen readers announce the loading state.

## Files touched

- `src/routes/{careers,donate,other-actions,resources,volunteer}/+page.server.ts` — streaming load.
- `src/routes/{careers,donate,other-actions,resources,volunteer}/+page.svelte` — `{#await}` wrapping.
- `src/lib/components/OrganizationGridSkeleton.svelte` (new) — skeleton component.

## Tests

- `yarn test:unit --run` — 100 tests pass.
- `yarn build` — clean build, no prerender warnings.
- `yarn lint` — clean.
- E2E `other-actions.test.ts` preserves its `data-testid="org-card-grid"` selector (only moved inside the `{:then}` branch — Playwright's `toBeAttached` auto-waits through the stream).

## Test plan

- [x] Unit tests pass
- [x] Build clean
- [ ] Deploy to dev, visit `/volunteer` and verify the approved org now appears without a redeploy
- [ ] Visit each listing page on a throttled connection and confirm the skeleton animates during the stream gap
- [ ] Simulate an API outage (stop the backend) and confirm `{:catch}` renders
- [ ] Confirm `/other-actions` e2e test still passes against the new structure

## Context

This unblocks the workflow where curators approve orgs via admin (PR #211) or the new `evaluate_pending` local command (PR #213) and expect them to show up on dev immediately.
