### PR TITLE
fix(routes): page-specific button labels + centered 3-per-row card layout

### DIFF
--- a/terramedic/src/lib/components/OrganizationCard.svelte
+++ b/terramedic/src/lib/components/OrganizationCard.svelte
@@ -1,12 +1,13 @@
 <script>
   import { Card, Button } from 'flowbite-svelte';
+  import { DEFAULT_ORG_ACTION_TEXT } from '$lib/components/organizationGrid.styles';
   import { trackEvent } from '$lib/utils/analytics';
 
   export let name = '';
   export let description = '';
   export let websiteUrl = '';
   export let imageUrl = '';
-  export let actionText = 'Visit Website';
+  export let actionText = DEFAULT_ORG_ACTION_TEXT;
   export let tags = [];
   export let tagColor = 'blue'; // 'blue', 'green', 'gold', 'purple', 'orange', 'red', 'gray'
   export let buttonColor = 'blue'; // 'blue', 'green', 'gold', 'purple'

--- a/terramedic/src/lib/components/OrganizationGrid.svelte
+++ b/terramedic/src/lib/components/OrganizationGrid.svelte
@@ -1,6 +1,10 @@
 <script>
   import OrganizationCard from '$lib/components/OrganizationCard.svelte';
   import OrganizationGridSkeleton from '$lib/components/OrganizationGridSkeleton.svelte';
+  import {
+    ORG_CARD_WRAPPER_CLASS,
+    ORG_GRID_CONTAINER_CLASS
+  } from '$lib/components/organizationGrid.styles';
   import { trackSectionView } from '$lib/utils/analytics';
 
   // Shared wrapper for listing pages (/volunteer, /donate, etc.) that
@@ -37,9 +41,9 @@
         container-narrow (max-w-5xl) with 1.5rem gaps, 2 per row on
         tablet, and full-width on phones.
       -->
-      <div class="flex flex-wrap justify-center gap-6">
+      <div class={ORG_GRID_CONTAINER_CLASS}>
         {#each organizations as org (org.id)}
-          <div class="w-full sm:w-72">
+          <div class={ORG_CARD_WRAPPER_CLASS}>
             <OrganizationCard
               name={org.name}
               description={org.description}

--- a/terramedic/src/lib/components/OrganizationGrid.svelte
+++ b/terramedic/src/lib/components/OrganizationGrid.svelte
@@ -14,6 +14,11 @@
   export let emptyText;
   export let analyticsSection;
   export let analyticsPage;
+  // Button label for every card on this page. Page-level override of
+  // `org.action_text` so /donate shows "Learn more", /volunteer shows
+  // "Volunteer", etc. — the stored `action_text` is auto-generated
+  // per-org ("Support {name}") and less contextual than the page verb.
+  export let actionText;
 </script>
 
 <div use:trackSectionView={{ section: analyticsSection, page: analyticsPage }}>
@@ -33,7 +38,7 @@
             tags={org.tags}
             {tagColor}
             {buttonColor}
-            actionText={org.action_text}
+            {actionText}
           />
         {/each}
       </div>

--- a/terramedic/src/lib/components/OrganizationGrid.svelte
+++ b/terramedic/src/lib/components/OrganizationGrid.svelte
@@ -8,7 +8,6 @@
   // / error states and attaches analytics to a wrapper that's present
   // in every branch so section_view fires regardless of outcome.
   export let promise;
-  export let gridClass;
   export let tagColor;
   export let buttonColor;
   export let emptyText;
@@ -23,23 +22,32 @@
 
 <div use:trackSectionView={{ section: analyticsSection, page: analyticsPage }}>
   {#await promise}
-    <OrganizationGridSkeleton {gridClass} />
+    <OrganizationGridSkeleton />
   {:then organizations}
     {#if organizations.length === 0}
       <p class="text-center text-gray-400">{emptyText}</p>
     {:else}
-      <div class={gridClass}>
+      <!--
+        Flex-wrap + justify-center instead of a CSS grid so rows with
+        fewer than 3 cards center under the header instead of
+        left-aligning. Card width 18rem gives 3 per row inside
+        container-narrow (max-w-5xl) with 1.5rem gaps, 2 per row on
+        tablet, and full-width on phones.
+      -->
+      <div class="flex flex-wrap justify-center gap-6">
         {#each organizations as org (org.id)}
-          <OrganizationCard
-            name={org.name}
-            description={org.description}
-            websiteUrl={org.website_url}
-            imageUrl={org.image_url}
-            tags={org.tags}
-            {tagColor}
-            {buttonColor}
-            {actionText}
-          />
+          <div class="w-full sm:w-72">
+            <OrganizationCard
+              name={org.name}
+              description={org.description}
+              websiteUrl={org.website_url}
+              imageUrl={org.image_url}
+              tags={org.tags}
+              {tagColor}
+              {buttonColor}
+              {actionText}
+            />
+          </div>
         {/each}
       </div>
     {/if}

--- a/terramedic/src/lib/components/OrganizationGrid.svelte
+++ b/terramedic/src/lib/components/OrganizationGrid.svelte
@@ -2,6 +2,7 @@
   import OrganizationCard from '$lib/components/OrganizationCard.svelte';
   import OrganizationGridSkeleton from '$lib/components/OrganizationGridSkeleton.svelte';
   import {
+    DEFAULT_ORG_ACTION_TEXT,
     ORG_CARD_WRAPPER_CLASS,
     ORG_GRID_CONTAINER_CLASS
   } from '$lib/components/organizationGrid.styles';
@@ -21,10 +22,7 @@
   // `org.action_text` so /donate shows "Learn more", /volunteer shows
   // "Volunteer", etc. — the stored `action_text` is auto-generated
   // per-org ("Support {name}") and less contextual than the page verb.
-  // Default matches OrganizationCard's default so a caller that
-  // forgets to pass one still renders a labeled button (and emits a
-  // sane analytics value) instead of "undefined".
-  export let actionText = 'Visit Website';
+  export let actionText = DEFAULT_ORG_ACTION_TEXT;
 </script>
 
 <div use:trackSectionView={{ section: analyticsSection, page: analyticsPage }}>

--- a/terramedic/src/lib/components/OrganizationGrid.svelte
+++ b/terramedic/src/lib/components/OrganizationGrid.svelte
@@ -17,7 +17,10 @@
   // `org.action_text` so /donate shows "Learn more", /volunteer shows
   // "Volunteer", etc. — the stored `action_text` is auto-generated
   // per-org ("Support {name}") and less contextual than the page verb.
-  export let actionText;
+  // Default matches OrganizationCard's default so a caller that
+  // forgets to pass one still renders a labeled button (and emits a
+  // sane analytics value) instead of "undefined".
+  export let actionText = 'Visit Website';
 </script>
 
 <div use:trackSectionView={{ section: analyticsSection, page: analyticsPage }}>

--- a/terramedic/src/lib/components/OrganizationGrid.svelte
+++ b/terramedic/src/lib/components/OrganizationGrid.svelte
@@ -34,13 +34,6 @@
     {#if organizations.length === 0}
       <p class="text-center text-gray-400">{emptyText}</p>
     {:else}
-      <!--
-        Flex-wrap + justify-center instead of a CSS grid so rows with
-        fewer than 3 cards center under the header instead of
-        left-aligning. Card width 18rem gives 3 per row inside
-        container-narrow (max-w-5xl) with 1.5rem gaps, 2 per row on
-        tablet, and full-width on phones.
-      -->
       <div class={ORG_GRID_CONTAINER_CLASS}>
         {#each organizations as org (org.id)}
           <div class={ORG_CARD_WRAPPER_CLASS}>

--- a/terramedic/src/lib/components/OrganizationGrid.svelte.test.ts
+++ b/terramedic/src/lib/components/OrganizationGrid.svelte.test.ts
@@ -5,7 +5,6 @@ import OrganizationGrid from './OrganizationGrid.svelte';
 import type { Organization } from '$lib/server/api';
 
 const baseProps = {
-  gridClass: 'grid gap-6 md:grid-cols-2',
   tagColor: 'blue',
   buttonColor: 'blue',
   emptyText: 'No organizations yet.',

--- a/terramedic/src/lib/components/OrganizationGrid.svelte.test.ts
+++ b/terramedic/src/lib/components/OrganizationGrid.svelte.test.ts
@@ -10,7 +10,8 @@ const baseProps = {
   buttonColor: 'blue',
   emptyText: 'No organizations yet.',
   analyticsSection: 'organizations',
-  analyticsPage: 'test'
+  analyticsPage: 'test',
+  actionText: 'Volunteer'
 };
 
 function makeOrg(overrides: Partial<Organization> = {}): Organization {
@@ -60,6 +61,21 @@ describe('OrganizationGrid', () => {
       expect(screen.getByText('Second Org')).toBeInTheDocument();
     });
     expect(screen.queryByText('No organizations yet.')).not.toBeInTheDocument();
+  });
+
+  test('button label uses the page-level actionText, not org.action_text', async () => {
+    const orgs = [makeOrg({ id: 1, name: 'Example Org', action_text: 'Support Example Org' })];
+    const promise = Promise.resolve(orgs);
+    render(OrganizationGrid, {
+      props: { ...baseProps, actionText: 'Learn more', promise }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Example Org')).toBeInTheDocument();
+    });
+    // Page-level verb wins over the auto-generated per-org label.
+    expect(screen.getByRole('link', { name: 'Learn more' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Support Example Org' })).not.toBeInTheDocument();
   });
 
   test('shows refresh-to-retry message when the promise rejects', async () => {

--- a/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
+++ b/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
@@ -1,20 +1,20 @@
 <script>
-  // Skeleton shown while the org list streams in. The caller passes
-  // `gridClass` to match its final grid so the layout doesn't jump
-  // when the real cards render. Defaults to the 3-column layout used
-  // by volunteer/donate.
+  // Skeleton shown while the org list streams in. Layout mirrors
+  // OrganizationGrid (flex-wrap + centered cards at a fixed 18rem
+  // width) so the real cards slot in without a reflow.
   export let count = 3;
-  export let gridClass = 'grid gap-6 md:grid-cols-2 lg:grid-cols-3';
 
   // Reactive so callers can pass a dynamic count prop and the grid
   // stays in sync.
   $: indices = [...Array(count).keys()];
 </script>
 
-<div class={gridClass} role="status" aria-live="polite" aria-busy="true">
+<div class="flex flex-wrap justify-center gap-6" role="status" aria-live="polite" aria-busy="true">
   <span class="sr-only">Loading organizations</span>
   {#each indices as i (i)}
-    <div class="!bg-navy flex h-full animate-pulse flex-col rounded-lg border border-white/10 p-5">
+    <div
+      class="!bg-navy flex h-full w-full animate-pulse flex-col rounded-lg border border-white/10 p-5 sm:w-72"
+    >
       <div class="mb-3 h-6 w-3/4 rounded bg-white/10"></div>
       <div class="mb-3 flex flex-wrap gap-1.5">
         <span class="inline-block h-5 w-16 rounded-full bg-white/10"></span>

--- a/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
+++ b/terramedic/src/lib/components/OrganizationGridSkeleton.svelte
@@ -1,4 +1,9 @@
 <script>
+  import {
+    ORG_CARD_WRAPPER_CLASS,
+    ORG_GRID_CONTAINER_CLASS
+  } from '$lib/components/organizationGrid.styles';
+
   // Skeleton shown while the org list streams in. Layout mirrors
   // OrganizationGrid (flex-wrap + centered cards at a fixed 18rem
   // width) so the real cards slot in without a reflow.
@@ -9,11 +14,11 @@
   $: indices = [...Array(count).keys()];
 </script>
 
-<div class="flex flex-wrap justify-center gap-6" role="status" aria-live="polite" aria-busy="true">
+<div class={ORG_GRID_CONTAINER_CLASS} role="status" aria-live="polite" aria-busy="true">
   <span class="sr-only">Loading organizations</span>
   {#each indices as i (i)}
     <div
-      class="!bg-navy flex h-full w-full animate-pulse flex-col rounded-lg border border-white/10 p-5 sm:w-72"
+      class="!bg-navy flex h-full animate-pulse flex-col rounded-lg border border-white/10 p-5 {ORG_CARD_WRAPPER_CLASS}"
     >
       <div class="mb-3 h-6 w-3/4 rounded bg-white/10"></div>
       <div class="mb-3 flex flex-wrap gap-1.5">

--- a/terramedic/src/lib/components/OrganizationGridSkeleton.svelte.test.ts
+++ b/terramedic/src/lib/components/OrganizationGridSkeleton.svelte.test.ts
@@ -16,19 +16,16 @@ describe('OrganizationGridSkeleton', () => {
     expect(cards).toHaveLength(6);
   });
 
-  test('applies default gridClass (3-column layout)', () => {
+  test('uses flex-wrap + justify-center layout', () => {
     const { container } = render(OrganizationGridSkeleton);
     const root = container.firstElementChild;
-    expect(root).toHaveClass('grid', 'gap-6', 'md:grid-cols-2', 'lg:grid-cols-3');
+    expect(root).toHaveClass('flex', 'flex-wrap', 'justify-center', 'gap-6');
   });
 
-  test('applies custom gridClass prop', () => {
-    const { container } = render(OrganizationGridSkeleton, {
-      props: { gridClass: 'grid gap-8 md:grid-cols-2' }
-    });
-    const root = container.firstElementChild;
-    expect(root).toHaveClass('grid', 'gap-8', 'md:grid-cols-2');
-    expect(root).not.toHaveClass('lg:grid-cols-3');
+  test('cards have responsive width (full on mobile, 18rem on sm+)', () => {
+    const { container } = render(OrganizationGridSkeleton, { props: { count: 1 } });
+    const card = container.querySelector('.animate-pulse');
+    expect(card).toHaveClass('w-full', 'sm:w-72');
   });
 
   test('exposes a polite live region that announces loading', () => {

--- a/terramedic/src/lib/components/organizationGrid.styles.ts
+++ b/terramedic/src/lib/components/organizationGrid.styles.ts
@@ -1,0 +1,6 @@
+// Shared layout classes used by OrganizationGrid and
+// OrganizationGridSkeleton. Keeping them here prevents the two components
+// from drifting and causing a visual reflow when streamed cards replace
+// skeletons.
+export const ORG_GRID_CONTAINER_CLASS = 'flex flex-wrap justify-center gap-6';
+export const ORG_CARD_WRAPPER_CLASS = 'w-full sm:w-72';

--- a/terramedic/src/lib/components/organizationGrid.styles.ts
+++ b/terramedic/src/lib/components/organizationGrid.styles.ts
@@ -1,6 +1,8 @@
-// Shared layout classes used by OrganizationGrid and
-// OrganizationGridSkeleton. Keeping them here prevents the two components
-// from drifting and causing a visual reflow when streamed cards replace
-// skeletons.
+// Shared constants for OrganizationCard, OrganizationGrid, and
+// OrganizationGridSkeleton. Keeping them here prevents the components
+// from drifting — the grid passes actionText through to each card and
+// the skeleton's layout must match the grid's so cards don't reflow
+// when streamed results replace the loading state.
 export const ORG_GRID_CONTAINER_CLASS = 'flex flex-wrap justify-center gap-6';
 export const ORG_CARD_WRAPPER_CLASS = 'w-full sm:w-72';
+export const DEFAULT_ORG_ACTION_TEXT = 'Visit Website';

--- a/terramedic/src/routes/careers/+page.svelte
+++ b/terramedic/src/routes/careers/+page.svelte
@@ -56,6 +56,7 @@
         emptyText="No environmental career boards yet — check back soon."
         analyticsSection="organizations"
         analyticsPage="careers"
+        actionText="Browse jobs"
       />
 
       <div class="mt-16 mb-6 text-center">

--- a/terramedic/src/routes/careers/+page.svelte
+++ b/terramedic/src/routes/careers/+page.svelte
@@ -50,7 +50,6 @@
 
       <OrganizationGrid
         promise={data.organizations}
-        gridClass="grid gap-6 md:grid-cols-2"
         tagColor="gold"
         buttonColor="gold"
         emptyText="No environmental career boards yet — check back soon."

--- a/terramedic/src/routes/donate/+page.svelte
+++ b/terramedic/src/routes/donate/+page.svelte
@@ -51,7 +51,6 @@
 
       <OrganizationGrid
         promise={data.organizations}
-        gridClass="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
         tagColor="green"
         buttonColor="green"
         emptyText="No donation opportunities yet — check back soon."

--- a/terramedic/src/routes/donate/+page.svelte
+++ b/terramedic/src/routes/donate/+page.svelte
@@ -57,6 +57,7 @@
         emptyText="No donation opportunities yet — check back soon."
         analyticsSection="organizations"
         analyticsPage="donate"
+        actionText="Learn more"
       />
 
       <div class="mt-16 mb-6 text-center">

--- a/terramedic/src/routes/other-actions/+page.svelte
+++ b/terramedic/src/routes/other-actions/+page.svelte
@@ -53,7 +53,6 @@
       <div class="mb-16" data-testid="org-card-grid">
         <OrganizationGrid
           promise={data.organizations}
-          gridClass="grid gap-6 md:grid-cols-2"
           tagColor="purple"
           buttonColor="purple"
           emptyText="No everyday-action organizations yet — check back soon."

--- a/terramedic/src/routes/other-actions/+page.svelte
+++ b/terramedic/src/routes/other-actions/+page.svelte
@@ -59,6 +59,7 @@
           emptyText="No everyday-action organizations yet — check back soon."
           analyticsSection="organizations"
           analyticsPage="other-actions"
+          actionText="Take action"
         />
       </div>
 

--- a/terramedic/src/routes/resources/+page.svelte
+++ b/terramedic/src/routes/resources/+page.svelte
@@ -42,7 +42,6 @@
       <div class="mx-auto mb-12 max-w-4xl px-4 sm:px-6">
         <OrganizationGrid
           promise={data.organizations}
-          gridClass="grid gap-8 md:grid-cols-2"
           tagColor="blue"
           buttonColor="blue"
           emptyText="No advocate resources yet — check back soon."

--- a/terramedic/src/routes/resources/+page.svelte
+++ b/terramedic/src/routes/resources/+page.svelte
@@ -39,17 +39,15 @@
         Tools, research, and support for those already engaged in advocacy work.
       </p>
 
-      <div class="mx-auto mb-12 max-w-4xl px-4 sm:px-6">
-        <OrganizationGrid
-          promise={data.organizations}
-          tagColor="blue"
-          buttonColor="blue"
-          emptyText="No advocate resources yet — check back soon."
-          analyticsSection="organizations"
-          analyticsPage="resources"
-          actionText="Explore resources"
-        />
-      </div>
+      <OrganizationGrid
+        promise={data.organizations}
+        tagColor="blue"
+        buttonColor="blue"
+        emptyText="No advocate resources yet — check back soon."
+        analyticsSection="organizations"
+        analyticsPage="resources"
+        actionText="Explore resources"
+      />
     </div>
   </main>
 

--- a/terramedic/src/routes/resources/+page.svelte
+++ b/terramedic/src/routes/resources/+page.svelte
@@ -48,6 +48,7 @@
           emptyText="No advocate resources yet — check back soon."
           analyticsSection="organizations"
           analyticsPage="resources"
+          actionText="Explore resources"
         />
       </div>
     </div>

--- a/terramedic/src/routes/volunteer/+page.svelte
+++ b/terramedic/src/routes/volunteer/+page.svelte
@@ -56,6 +56,7 @@
         emptyText="No volunteer organizations yet — check back soon."
         analyticsSection="organizations"
         analyticsPage="volunteer"
+        actionText="Volunteer"
       />
 
       <div class="mt-16 mb-6 text-center">

--- a/terramedic/src/routes/volunteer/+page.svelte
+++ b/terramedic/src/routes/volunteer/+page.svelte
@@ -50,7 +50,6 @@
 
       <OrganizationGrid
         promise={data.organizations}
-        gridClass="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
         tagColor="blue"
         buttonColor="blue"
         emptyText="No volunteer organizations yet — check back soon."


### PR DESCRIPTION
## Summary

Two fixes on the org listing pages (`/volunteer`, `/donate`, `/other-actions`, `/resources`, `/careers`):

### 1. Page-specific button labels

Every card was showing **"Support {name}"** because `create_org_from_evaluation` auto-generates that string and `OrganizationGrid` was passing `org.action_text` through verbatim. The old per-context labels came from `seed_data.json`, which was removed in #199; since then, every new org flows through the auto-generator.

Each listing page now passes its own verb to `OrganizationGrid.actionText`:

| Page | Button |
|---|---|
| `/volunteer` | Volunteer |
| `/donate` | **Learn more** (501c3 — avoid directly solicitational verb on a listing page) |
| `/other-actions` | Take action |
| `/resources` | Explore resources |
| `/careers` | Browse jobs |

The per-org `action_text` field stays on the model for a future curator-override path.

### 2. Centered 3-per-row card layout

CSS grid (`md:grid-cols-2 lg:grid-cols-3`) left-aligned partial rows — a page with only 1 or 2 orgs would pin cards to the top-left instead of centering them under the header. With orgs trickling in from curation, single-card pages are common.

Replaced the configurable grid with a fixed flex-wrap + `justify-center` layout at 18rem card width:

- 1 card: centered under header
- 2 cards: both centered together
- 3+ cards: natural 3-per-row at `lg`, 2 at tablet, 1 on mobile
- Skeleton mirrors the same layout so real cards slot in without reflow

Dropped the `gridClass` prop from `OrganizationGrid` / `OrganizationGridSkeleton` since all pages now use the same layout.

## Tests

- 112 unit tests pass.
- `OrganizationGrid.svelte.test.ts` asserts page-level `actionText` wins over `org.action_text`.
- `OrganizationGridSkeleton.svelte.test.ts` updated to verify the new flex-wrap layout + responsive card width (`w-full sm:w-72`).

## Test plan

- [x] Unit tests, lint, build all pass
- [ ] Deploy to dev, verify each listing page shows the expected verb on every card
- [ ] Verify a page with 1 org centers the card under the header; 2 orgs sit together centered; 3+ orgs fill a row
- [ ] Check mobile: cards become full-width, still centered
- [ ] Curator can still type a custom value into `OrganizationEvaluation.action_text` in the admin (unused on cards for now but preserved for future)