### PR TITLE
feat(curation): curb category over-classification end-to-end

### DIFF
--- a/backend/curation/prompt.py
+++ b/backend/curation/prompt.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 # Bump this version whenever SYSTEM_PROMPT is modified.
 # Format: YYYY.MM.N where N resets to 1 each month.
-PROMPT_VERSION: str = "2026.04.9"
+PROMPT_VERSION: str = "2026.04.10"
 
 # Fields injected programmatically by evaluate.py after the model responds.
 # They are stripped from the schema before embedding in the prompt so the
@@ -151,6 +151,40 @@ Organizations that help people **find or transition into environmental work**.
 Examples: Climatebase (climate job board + community), Green Jobs Network \
 (environmental job listings), Climate Careers (UK — green job \
 listings + career resources).
+
+## Assignment discipline
+
+Most organizations earn **one or two categories**. Three is unusual. \
+Four or five is almost always over-classification and will be \
+trimmed by the human reviewer — which signals the evaluation is \
+noisy.
+
+Before assigning a category, ask: is this pathway a **core, \
+prominent part of what the organization offers to the public** — \
+or is it a minor, secondary feature? Only assign the category when \
+the answer is clearly "core."
+
+Anti-patterns to avoid:
+- A blog with occasional sustainability tips does **not** earn \
+`everyday`. That category is for orgs whose primary public offer is \
+practical daily-action guidance.
+- A newsletter signup or a links page to external reports does \
+**not** earn `resource`. That category is for orgs that themselves \
+produce research, toolkits, or training content as a core output.
+- A "We're hiring" page or occasional job posting does **not** earn \
+`career`. That category is for orgs whose primary audience includes \
+people seeking climate work — job boards, fellowships, career \
+communities.
+- A "Donate" button in the site header does **not** earn `donate`. \
+That category is for orgs where donations are a central, accountable \
+pathway with a clear theory of change.
+- Hosting a speaker series or publishing an explainer does **not** \
+earn `volunteer`. That category requires an actual hands-on or \
+advocacy pathway people can sign up for.
+
+**When in doubt, leave the category off.** Under-classification is \
+easy for a reviewer to correct; over-classification pollutes the \
+database and wastes reviewer time.
 
 ## General inclusion and exclusion rules
 

--- a/backend/curation/prompt.py
+++ b/backend/curation/prompt.py
@@ -196,9 +196,10 @@ communities.
 - A "Donate" button in the site header does **not** earn `donate`. \
 That category is for orgs where donations are a central, accountable \
 pathway with a clear theory of change.
-- Hosting a speaker series or publishing an explainer does **not** \
-earn `volunteer`. That category requires an actual hands-on or \
-advocacy pathway people can sign up for.
+- A "Sign the petition" button does **not** earn `volunteer`. That \
+category is for orgs offering sustained participation pathways — \
+canvassing, lobby days, letter writing, restoration work, local \
+chapter meetings.
 
 **When in doubt, leave the category off.** Under-classification is \
 easy for a reviewer to correct; over-classification pollutes the \

--- a/backend/curation/prompt.py
+++ b/backend/curation/prompt.py
@@ -66,6 +66,24 @@ their own? A focused conservation org, a regional volunteer network, a niche \
 career platform, or a research group producing guides for advocates all belong. \
 A massive global NGO that everyone already knows about does not.
 
+## Description guidelines
+
+The ``org_metadata.description`` field is rendered verbatim on \
+Terramedic's public listing cards, side by side with other orgs. \
+Uneven lengths make the grid look jittery, so aim for consistency:
+
+- **Write one to two sentences, roughly 120-180 characters total.** \
+Treat 200 as a hard ceiling.
+- Lead with **what the org does**, not what it is. Prefer *"Protects \
+old-growth rainforest by funding Indigenous-led land stewardship in \
+Borneo"* over *"A 501(c)(3) nonprofit dedicated to rainforest \
+conservation."*
+- Drop filler phrases like *"is an organization that"*, *"founded \
+in..."*, or *"mission is to..."* — they eat characters without \
+adding information.
+- Don't pad short orgs to hit the target; concision beats filler. \
+Don't truncate mid-thought to fit either — rewrite instead.
+
 ## Nomination categories
 
 Each organization should fit one or more of the categories below. If the \

--- a/backend/curation/tests/test_evaluate.py
+++ b/backend/curation/tests/test_evaluate.py
@@ -1243,3 +1243,24 @@ class TestMain:
 
         expected = default_dir / "example-org.json"
         assert expected.exists()
+
+
+class TestCategoryAssignmentDiscipline:
+    """The prompt must warn the model off over-classifying organizations.
+
+    Reviewers were routinely manually trimming 3-4 category assignments
+    down to the 1-2 that actually fit the org.
+    """
+
+    def test_prompt_has_assignment_discipline_section(self) -> None:
+        assert "Assignment discipline" in SYSTEM_PROMPT
+
+    def test_prompt_calls_out_typical_category_count(self) -> None:
+        """The prompt should anchor the model on 1-2 categories as the
+        typical count, so it stops routinely assigning 3-5."""
+        assert "one or two" in SYSTEM_PROMPT
+
+    def test_prompt_defaults_to_leaving_categories_off_when_unsure(
+        self,
+    ) -> None:
+        assert "When in doubt, leave the category off" in SYSTEM_PROMPT

--- a/backend/curation/tests/test_evaluate.py
+++ b/backend/curation/tests/test_evaluate.py
@@ -1264,3 +1264,23 @@ class TestCategoryAssignmentDiscipline:
         self,
     ) -> None:
         assert "When in doubt, leave the category off" in SYSTEM_PROMPT
+
+
+class TestDescriptionLengthGuidance:
+    """Org descriptions must be roughly the same length across orgs so
+    card layouts don't jitter — the current cards render the full
+    description with no truncation, so raw character count drives
+    visual variation.
+    """
+
+    def test_prompt_has_description_guidelines_section(self) -> None:
+        assert "Description guidelines" in SYSTEM_PROMPT
+
+    def test_prompt_asks_for_one_to_two_sentences(self) -> None:
+        assert "one to two sentences" in SYSTEM_PROMPT
+
+    def test_prompt_anchors_on_character_target(self) -> None:
+        """The prompt must give the model a concrete character budget
+        (120-180) so descriptions land in a narrow band."""
+        assert "120" in SYSTEM_PROMPT
+        assert "180" in SYSTEM_PROMPT

--- a/backend/curation/tests/test_evaluate.py
+++ b/backend/curation/tests/test_evaluate.py
@@ -1281,6 +1281,7 @@ class TestDescriptionLengthGuidance:
 
     def test_prompt_anchors_on_character_target(self) -> None:
         """The prompt must give the model a concrete character budget
-        (120-180) so descriptions land in a narrow band."""
-        assert "120" in SYSTEM_PROMPT
-        assert "180" in SYSTEM_PROMPT
+        (120-180) so descriptions land in a narrow band. Assert the
+        range as one token so incidental three-digit substrings
+        elsewhere in the prompt can't satisfy it."""
+        assert "120-180 characters" in SYSTEM_PROMPT

--- a/backend/terramedic/organizations/admin.py
+++ b/backend/terramedic/organizations/admin.py
@@ -12,6 +12,9 @@ from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from parler.admin import TranslatableAdmin
 
+from terramedic.organizations.evaluation_actions import (
+    sync_org_categories_from_evaluation,
+)
 from terramedic.organizations.models import (
     SDG,
     Category,
@@ -607,6 +610,22 @@ class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
                 obj.organization.is_active = False
                 obj.organization.save(update_fields=["is_active"])
         super().save_model(request, obj, form, change)
+
+        # On the APPROVED transition, create_org_on_approval in
+        # signals.py handles category assignment via
+        # create_org_from_evaluation. For subsequent edits of
+        # reviewer_categories on an already-approved evaluation the
+        # signal short-circuits (it only handles the transition), so
+        # we re-sync the linked org's categories here to keep the
+        # form and the live org from drifting apart.
+        if (
+            change
+            and "reviewer_categories" in form.changed_data
+            and "status" not in form.changed_data
+            and obj.status == ReviewStatus.APPROVED
+            and obj.organization is not None
+        ):
+            sync_org_categories_from_evaluation(obj)
 
     @admin.action(description="Approve selected evaluations")
     def approve_evaluations(

--- a/backend/terramedic/organizations/admin.py
+++ b/backend/terramedic/organizations/admin.py
@@ -377,16 +377,19 @@ class EvaluationReviewForm(forms.ModelForm):  # type: ignore[type-arg]
         self.fields["reviewer_categories"].choices = list(  # type: ignore[attr-defined]
             Category.objects.values_list("slug", "label"),
         )
-        instance = kwargs.get("instance")
-        if instance is None:
+        # Use self.instance (populated by ModelForm.__init__ whether
+        # the caller passed instance positionally or by keyword) and
+        # gate on pk so unbound forms — e.g. the admin's "add" view —
+        # skip prefill cleanly.
+        if self.instance.pk is None:
             return
-        if instance.reviewer_categories is not None:
+        if self.instance.reviewer_categories is not None:
             self.initial["reviewer_categories"] = list(
-                instance.reviewer_categories,
+                self.instance.reviewer_categories,
             )
             return
         ai_categories = (
-            (instance.evaluation_data or {})
+            (self.instance.evaluation_data or {})
             .get("accessibility", {})
             .get("categories", [])
         )

--- a/backend/terramedic/organizations/admin.py
+++ b/backend/terramedic/organizations/admin.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from django import forms
 from django.contrib import admin, messages
 from django.db import connection
 from django.db.models import Count, Q, QuerySet
@@ -335,6 +336,64 @@ class CategoryFilter(admin.SimpleListFilter):
         return queryset.filter(pk__in=pks)
 
 
+class EvaluationReviewForm(forms.ModelForm):  # type: ignore[type-arg]
+    """Admin detail form with per-category checkboxes.
+
+    Prefilled with the AI's ``accessibility.categories`` the first time
+    a reviewer opens the form, so unchecking is the reviewer's only
+    action when the AI over-classified. On save, the reviewer's
+    selection (even if unchanged) is persisted to
+    ``reviewer_categories``, which the ``create_org_on_approval``
+    signal uses as the source of truth for the new Organization's
+    categories.
+    """
+
+    reviewer_categories = forms.MultipleChoiceField(
+        choices=(),
+        widget=forms.CheckboxSelectMultiple,
+        required=False,
+        label="Categories to assign on approval",
+        help_text=(
+            "Prefilled with the AI's proposed list. Uncheck any that"
+            " don't fit before approving — this replaces editing the"
+            " Organization record after the fact."
+        ),
+    )
+
+    class Meta:
+        model = OrganizationEvaluation
+        fields = (
+            "status",
+            "reviewer_reasoning",
+            "reviewer_categories",
+        )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.fields["reviewer_categories"].choices = list(  # type: ignore[attr-defined]
+            Category.objects.values_list("slug", "label"),
+        )
+        instance = kwargs.get("instance")
+        if instance is None:
+            return
+        if instance.reviewer_categories is not None:
+            self.initial["reviewer_categories"] = list(
+                instance.reviewer_categories,
+            )
+            return
+        ai_categories = (
+            (instance.evaluation_data or {})
+            .get("accessibility", {})
+            .get("categories", [])
+        )
+        # 'other' is in the schema as an AI escape hatch but isn't a
+        # real Category row — don't pre-check a box that maps to
+        # nothing on approval.
+        self.initial["reviewer_categories"] = [
+            slug for slug in ai_categories if slug != "other"
+        ]
+
+
 @admin.register(OrganizationEvaluation)
 class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     list_display = [
@@ -347,6 +406,7 @@ class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
         "reviewed_at",
     ]
     list_filter = ["status", EvidenceScoreFilter, CategoryFilter]
+    form = EvaluationReviewForm
     # search_fields must be non-empty for Django to render the search
     # box.  The default icontains query on "status" is harmless but
     # unused — actual search logic lives in get_search_results below.
@@ -365,6 +425,7 @@ class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
             {
                 "fields": (
                     "status",
+                    "reviewer_categories",
                     "reviewer_reasoning",
                 ),
                 "description": (

--- a/backend/terramedic/organizations/admin.py
+++ b/backend/terramedic/organizations/admin.py
@@ -357,9 +357,10 @@ class EvaluationReviewForm(forms.ModelForm):  # type: ignore[type-arg]
         required=False,
         label="Categories to assign on approval",
         help_text=(
-            "Prefilled with the AI's proposed list. Uncheck any that"
-            " don't fit before approving — this replaces editing the"
-            " Organization record after the fact."
+            "Prefilled with the AI's proposed list. Edits here flow"
+            " to the linked Organization — before approval via the"
+            " create path, and after approval via re-sync. Uncheck"
+            " any that don't fit."
         ),
     )
 

--- a/backend/terramedic/organizations/admin.py
+++ b/backend/terramedic/organizations/admin.py
@@ -611,17 +611,18 @@ class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
                 obj.organization.save(update_fields=["is_active"])
         super().save_model(request, obj, form, change)
 
-        # On the APPROVED transition, create_org_on_approval in
-        # signals.py handles category assignment via
-        # create_org_from_evaluation. For subsequent edits of
-        # reviewer_categories on an already-approved evaluation the
-        # signal short-circuits (it only handles the transition), so
-        # we re-sync the linked org's categories here to keep the
-        # form and the live org from drifting apart.
+        # Keep the linked Organization's categories aligned with
+        # reviewer_categories whenever the reviewer edits them on an
+        # approved evaluation. On the initial PENDING→APPROVED save
+        # the post_save signal in signals.py already assigns
+        # categories via create_org_from_evaluation, so this call is
+        # an idempotent no-op in that case. On every other approved
+        # save — including APPROVED→PENDING→APPROVED cycles where
+        # the signal only reactivates is_active — this is the path
+        # that propagates the edit to the live org.
         if (
             change
             and "reviewer_categories" in form.changed_data
-            and "status" not in form.changed_data
             and obj.status == ReviewStatus.APPROVED
             and obj.organization is not None
         ):

--- a/backend/terramedic/organizations/admin.py
+++ b/backend/terramedic/organizations/admin.py
@@ -396,6 +396,16 @@ class EvaluationReviewForm(forms.ModelForm):  # type: ignore[type-arg]
         # 'other' is in the schema as an AI escape hatch but isn't a
         # real Category row — don't pre-check a box that maps to
         # nothing on approval.
+        #
+        # Side effect: the first no-op save of this form on a
+        # NULL-reviewer_categories evaluation promotes the implicit
+        # AI fallback to an explicit override (construct_instance
+        # writes form.initial back to the instance). The resolved
+        # category set is identical, so nothing breaks at approval
+        # time — but later schema changes to the AI list won't
+        # shadow through for that evaluation. If that becomes a
+        # problem, compare cleaned_data to the AI list before
+        # writing rather than adding drift-detection here.
         self.initial["reviewer_categories"] = [
             slug for slug in ai_categories if slug != "other"
         ]

--- a/backend/terramedic/organizations/admin.py
+++ b/backend/terramedic/organizations/admin.py
@@ -344,11 +344,20 @@ class EvaluationReviewForm(forms.ModelForm):  # type: ignore[type-arg]
 
     Prefilled with the AI's ``accessibility.categories`` the first time
     a reviewer opens the form, so unchecking is the reviewer's only
-    action when the AI over-classified. On save, the reviewer's
-    selection (even if unchanged) is persisted to
-    ``reviewer_categories``, which the ``create_org_on_approval``
-    signal uses as the source of truth for the new Organization's
-    categories.
+    action when the AI over-classified. On save:
+
+    * **Edited away from the AI list** — the reviewer's selection is
+      persisted to ``reviewer_categories`` as an explicit override.
+    * **Confirmed unchanged (still matches the AI list)** —
+      ``clean_reviewer_categories`` returns ``None`` so the field
+      stays ``NULL``, and the evaluation keeps tracking the AI list
+      rather than freezing today's list as a snapshot.
+
+    Either way, ``OrganizationEvaluationAdmin.save_model`` resyncs the
+    linked ``Organization.categories`` to the evaluation's effective
+    set — ``reviewer_categories`` when present, else the AI list —
+    so the admin form is authoritative for the linked org's
+    categories on every save.
     """
 
     reviewer_categories = forms.MultipleChoiceField(

--- a/backend/terramedic/organizations/admin.py
+++ b/backend/terramedic/organizations/admin.py
@@ -388,27 +388,46 @@ class EvaluationReviewForm(forms.ModelForm):  # type: ignore[type-arg]
                 self.instance.reviewer_categories,
             )
             return
+        # 'other' is in the schema as an AI escape hatch but isn't a
+        # real Category row — don't pre-check a box that maps to
+        # nothing on approval.
+        self.initial["reviewer_categories"] = self._ai_fallback_slugs()
+
+    def _ai_fallback_slugs(self) -> list[str]:
+        """Slugs the AI proposed, filtered to ones that map to a real
+        Category row. Used both for prefill and for NULL-preservation
+        in ``clean_reviewer_categories``."""
         ai_categories = (
             (self.instance.evaluation_data or {})
             .get("accessibility", {})
             .get("categories", [])
         )
-        # 'other' is in the schema as an AI escape hatch but isn't a
-        # real Category row — don't pre-check a box that maps to
-        # nothing on approval.
-        #
-        # Side effect: the first no-op save of this form on a
-        # NULL-reviewer_categories evaluation promotes the implicit
-        # AI fallback to an explicit override (construct_instance
-        # writes form.initial back to the instance). The resolved
-        # category set is identical, so nothing breaks at approval
-        # time — but later schema changes to the AI list won't
-        # shadow through for that evaluation. If that becomes a
-        # problem, compare cleaned_data to the AI list before
-        # writing rather than adding drift-detection here.
-        self.initial["reviewer_categories"] = [
-            slug for slug in ai_categories if slug != "other"
-        ]
+        return [slug for slug in ai_categories if slug != "other"]
+
+    def clean_reviewer_categories(self) -> list[str] | None:
+        """Preserve NULL when the reviewer confirms the AI defaults.
+
+        The field prefills from the AI list when
+        ``instance.reviewer_categories`` is ``NULL``, so a reviewer
+        opening the form sees the AI-proposed categories as checked
+        boxes. If they save without toggling any box, the submission
+        equals the prefilled list — but that's "I accept the AI
+        defaults," not "I'm explicitly choosing this exact list."
+        Returning ``None`` in that case keeps the DB value ``NULL``,
+        so the evaluation continues to follow the AI list (which can
+        evolve) rather than freezing a snapshot of today's list as
+        an explicit override.
+        """
+        submitted = self.cleaned_data.get("reviewer_categories") or []
+        if self.instance.pk is None:
+            return submitted
+        if self.instance.reviewer_categories is not None:
+            # Existing override — respect whatever the reviewer submits,
+            # including the AI list if that's what they chose.
+            return submitted
+        if set(submitted) == set(self._ai_fallback_slugs()):
+            return None
+        return submitted
 
 
 @admin.register(OrganizationEvaluation)
@@ -625,18 +644,18 @@ class OrganizationEvaluationAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
                 obj.organization.save(update_fields=["is_active"])
         super().save_model(request, obj, form, change)
 
-        # Keep the linked Organization's categories aligned with
-        # reviewer_categories whenever the reviewer edits them on an
-        # approved evaluation. On the initial PENDING→APPROVED save
-        # the post_save signal in signals.py already assigns
-        # categories via create_org_from_evaluation, so this call is
-        # an idempotent no-op in that case. On every other approved
-        # save — including APPROVED→PENDING→APPROVED cycles where
-        # the signal only reactivates is_active — this is the path
-        # that propagates the edit to the live org.
+        # Admin form saves are authoritative: whenever the reviewer
+        # submits the change form for an approved, linked evaluation,
+        # align the org's categories with the evaluation's resolved
+        # set. This covers every relevant case — explicit category
+        # edits, no-op saves (sync is idempotent), and
+        # APPROVED→PENDING→APPROVED cycles where the signal only
+        # reactivates is_active. The alternative — triggering on
+        # form.changed_data — misses the NULL-preservation path from
+        # clean_reviewer_categories (which surfaces the cleaned
+        # value, while has_changed works off raw form data).
         if (
             change
-            and "reviewer_categories" in form.changed_data
             and obj.status == ReviewStatus.APPROVED
             and obj.organization is not None
         ):

--- a/backend/terramedic/organizations/evaluation_actions.py
+++ b/backend/terramedic/organizations/evaluation_actions.py
@@ -19,17 +19,27 @@ def create_org_from_evaluation(
 ) -> Organization:
     """Create an Organization from evaluation data.
 
-    Assigns every valid category from the evaluation's
-    ``accessibility.categories`` array. If none are valid
-    (for example, all entries are ``"other"``), the
-    organization is filed under ``resource`` as a fallback
-    so it still shows up somewhere.
+    Categories are resolved in this order:
+
+    1. ``evaluation.reviewer_categories`` — the reviewer's explicit
+       choice. Set via the admin detail form. ``NULL`` means "no
+       override" (fall through); an empty list means "reviewer cleared
+       all categories" and triggers the ``resource`` fallback.
+    2. ``accessibility.categories`` from the AI — the legacy / bulk
+       approve path.
+
+    If the resolved list contains no valid slugs (for example, all
+    entries are ``"other"``), the organization is filed under
+    ``resource`` as a fallback so it still shows up somewhere.
     """
     data = evaluation.evaluation_data
     meta = data.get("org_metadata", {})
     accessibility = data.get("accessibility", {})
 
-    requested = accessibility.get("categories", [])
+    if evaluation.reviewer_categories is not None:
+        requested = evaluation.reviewer_categories
+    else:
+        requested = accessibility.get("categories", [])
     valid_categories = list(Category.objects.filter(slug__in=requested))
     if not valid_categories:
         valid_categories = list(Category.objects.filter(slug="resource"))

--- a/backend/terramedic/organizations/evaluation_actions.py
+++ b/backend/terramedic/organizations/evaluation_actions.py
@@ -35,8 +35,8 @@ def _resolve_categories(
     if evaluation.reviewer_categories is not None:
         requested = evaluation.reviewer_categories
     else:
-        accessibility = evaluation.evaluation_data.get("accessibility", {})
-        requested = accessibility.get("categories", [])
+        data = evaluation.evaluation_data or {}
+        requested = data.get("accessibility", {}).get("categories", [])
     valid_categories = list(Category.objects.filter(slug__in=requested))
     if not valid_categories:
         valid_categories = list(Category.objects.filter(slug="resource"))
@@ -50,7 +50,7 @@ def create_org_from_evaluation(
 
     See ``_resolve_categories`` for how the category set is chosen.
     """
-    data = evaluation.evaluation_data
+    data = evaluation.evaluation_data or {}
     meta = data.get("org_metadata", {})
 
     org = Organization(

--- a/backend/terramedic/organizations/evaluation_actions.py
+++ b/backend/terramedic/organizations/evaluation_actions.py
@@ -14,35 +14,44 @@ from terramedic.organizations.models import (
 )
 
 
+def _resolve_categories(
+    evaluation: OrganizationEvaluation,
+) -> list[Category]:
+    """Resolve the list of Category rows to attach to the Organization.
+
+    Precedence:
+
+    1. ``evaluation.reviewer_categories`` — the reviewer's explicit
+       choice. ``NULL`` means "no override" (fall through); an empty
+       list means "reviewer cleared all categories" and triggers the
+       ``resource`` fallback.
+    2. ``accessibility.categories`` from the AI — the legacy / bulk
+       approve path.
+
+    If the resolved list contains no valid slugs (for example, all
+    entries are ``"other"``), ``resource`` is returned as a fallback
+    so the org still surfaces somewhere.
+    """
+    if evaluation.reviewer_categories is not None:
+        requested = evaluation.reviewer_categories
+    else:
+        accessibility = evaluation.evaluation_data.get("accessibility", {})
+        requested = accessibility.get("categories", [])
+    valid_categories = list(Category.objects.filter(slug__in=requested))
+    if not valid_categories:
+        valid_categories = list(Category.objects.filter(slug="resource"))
+    return valid_categories
+
+
 def create_org_from_evaluation(
     evaluation: OrganizationEvaluation,
 ) -> Organization:
     """Create an Organization from evaluation data.
 
-    Categories are resolved in this order:
-
-    1. ``evaluation.reviewer_categories`` — the reviewer's explicit
-       choice. Set via the admin detail form. ``NULL`` means "no
-       override" (fall through); an empty list means "reviewer cleared
-       all categories" and triggers the ``resource`` fallback.
-    2. ``accessibility.categories`` from the AI — the legacy / bulk
-       approve path.
-
-    If the resolved list contains no valid slugs (for example, all
-    entries are ``"other"``), the organization is filed under
-    ``resource`` as a fallback so it still shows up somewhere.
+    See ``_resolve_categories`` for how the category set is chosen.
     """
     data = evaluation.evaluation_data
     meta = data.get("org_metadata", {})
-    accessibility = data.get("accessibility", {})
-
-    if evaluation.reviewer_categories is not None:
-        requested = evaluation.reviewer_categories
-    else:
-        requested = accessibility.get("categories", [])
-    valid_categories = list(Category.objects.filter(slug__in=requested))
-    if not valid_categories:
-        valid_categories = list(Category.objects.filter(slug="resource"))
 
     org = Organization(
         name=meta.get("name", ""),
@@ -53,5 +62,23 @@ def create_org_from_evaluation(
     org.set_current_language("en")
     org.description = meta.get("description", "")
     org.save()
-    org.categories.set(valid_categories)
+    org.categories.set(_resolve_categories(evaluation))
     return org
+
+
+def sync_org_categories_from_evaluation(
+    evaluation: OrganizationEvaluation,
+) -> None:
+    """Re-apply the resolved category set to the linked Organization.
+
+    For already-approved evaluations whose ``reviewer_categories`` was
+    edited on the admin form. The post_save signal short-circuits when
+    an org is already linked (it only handles the APPROVED transition),
+    so changes to ``reviewer_categories`` after approval would silently
+    desync the Organization's categories without this sync.
+
+    No-op if no Organization is linked.
+    """
+    if evaluation.organization is None:
+        return
+    evaluation.organization.categories.set(_resolve_categories(evaluation))

--- a/backend/terramedic/organizations/migrations/0020_add_reviewer_categories.py
+++ b/backend/terramedic/organizations/migrations/0020_add_reviewer_categories.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("organizations", "0019_remove_action_text"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="organizationevaluation",
+            name="reviewer_categories",
+            field=models.JSONField(
+                blank=True,
+                default=None,
+                help_text=(
+                    "Reviewer-chosen category slugs for the created"
+                    " Organization. NULL means use the AI's"
+                    " accessibility.categories list verbatim."
+                ),
+                null=True,
+            ),
+        ),
+    ]

--- a/backend/terramedic/organizations/migrations/0020_add_reviewer_categories.py
+++ b/backend/terramedic/organizations/migrations/0020_add_reviewer_categories.py
@@ -15,10 +15,13 @@ class Migration(migrations.Migration):
                 blank=True,
                 default=None,
                 help_text=(
-                    "Reviewer-chosen category slugs for the created"
+                    "Reviewer-chosen category slugs for the linked"
                     " Organization. NULL means fall back to the AI's"
                     " accessibility.categories list, filtered to known"
-                    " Category slugs."
+                    " Category slugs. Edits here flow through to the"
+                    " linked Organization — on the APPROVED transition"
+                    " via the create path, and on subsequent admin"
+                    " saves via re-sync."
                 ),
                 null=True,
             ),

--- a/backend/terramedic/organizations/migrations/0020_add_reviewer_categories.py
+++ b/backend/terramedic/organizations/migrations/0020_add_reviewer_categories.py
@@ -16,8 +16,9 @@ class Migration(migrations.Migration):
                 default=None,
                 help_text=(
                     "Reviewer-chosen category slugs for the created"
-                    " Organization. NULL means use the AI's"
-                    " accessibility.categories list verbatim."
+                    " Organization. NULL means fall back to the AI's"
+                    " accessibility.categories list, filtered to known"
+                    " Category slugs."
                 ),
                 null=True,
             ),

--- a/backend/terramedic/organizations/models/evaluation.py
+++ b/backend/terramedic/organizations/models/evaluation.py
@@ -75,6 +75,16 @@ class OrganizationEvaluation(models.Model):
             "Reasoning when overriding the AI recommendation."
         ),
     )
+    reviewer_categories: Any = models.JSONField(
+        null=True,
+        blank=True,
+        default=None,
+        help_text=(
+            "Reviewer-chosen category slugs for the created"
+            " Organization. NULL means use the AI's"
+            " accessibility.categories list verbatim."
+        ),
+    )
     reviewed_at = models.DateTimeField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 

--- a/backend/terramedic/organizations/models/evaluation.py
+++ b/backend/terramedic/organizations/models/evaluation.py
@@ -80,10 +80,12 @@ class OrganizationEvaluation(models.Model):
         blank=True,
         default=None,
         help_text=(
-            "Reviewer-chosen category slugs for the created"
+            "Reviewer-chosen category slugs for the linked"
             " Organization. NULL means fall back to the AI's"
             " accessibility.categories list, filtered to known"
-            " Category slugs."
+            " Category slugs. Edits here flow through to the linked"
+            " Organization — on the APPROVED transition via the"
+            " create path, and on subsequent admin saves via re-sync."
         ),
     )
     reviewed_at = models.DateTimeField(null=True, blank=True)

--- a/backend/terramedic/organizations/models/evaluation.py
+++ b/backend/terramedic/organizations/models/evaluation.py
@@ -81,8 +81,9 @@ class OrganizationEvaluation(models.Model):
         default=None,
         help_text=(
             "Reviewer-chosen category slugs for the created"
-            " Organization. NULL means use the AI's"
-            " accessibility.categories list verbatim."
+            " Organization. NULL means fall back to the AI's"
+            " accessibility.categories list, filtered to known"
+            " Category slugs."
         ),
     )
     reviewed_at = models.DateTimeField(null=True, blank=True)

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -1367,3 +1367,79 @@ class TestReviewerCategoriesPostApprovalSync:
         assert list(
             org.categories.values_list("slug", flat=True),
         ) == ["donate"]
+
+    def test_reapproval_with_category_edit_syncs_org(
+        self,
+        admin_client: Client,
+        admin_user: User,
+    ) -> None:
+        """Un-approve then re-approve in two form submits, changing
+        reviewer_categories on the re-approval save. The post_save
+        signal only reactivates is_active on the re-approval (it
+        doesn't touch categories when an org is already linked), so
+        the sync must run even when status is also in changed_data —
+        otherwise the DB row drifts from the linked Organization.
+        """
+        ev = OrganizationEvaluation.objects.create(
+            evaluation_data=_make_evaluation_data(
+                accessibility={
+                    "categories": ["donate", "volunteer", "resource"],
+                },
+            ),
+        )
+        change_url = (
+            f"/admin/organizations/organizationevaluation/"
+            f"{ev.pk}/change/"
+        )
+        # First approval — signal creates org with full AI list.
+        admin_client.post(
+            change_url,
+            {
+                "status": ReviewStatus.APPROVED,
+                "reviewer_reasoning": "",
+                "reviewer_categories": [
+                    "donate", "volunteer", "resource",
+                ],
+                "_save": "Save",
+            },
+        )
+        ev.refresh_from_db()
+        org = ev.organization
+        assert org is not None
+        assert set(
+            org.categories.values_list("slug", flat=True),
+        ) == {"donate", "volunteer", "resource"}
+
+        # Un-approve.
+        admin_client.post(
+            change_url,
+            {
+                "status": ReviewStatus.REJECTED,
+                "reviewer_reasoning": "needs trimming",
+                "reviewer_categories": [
+                    "donate", "volunteer", "resource",
+                ],
+                "_save": "Save",
+            },
+        )
+
+        # Re-approve AND change reviewer_categories in the same save.
+        admin_client.post(
+            change_url,
+            {
+                "status": ReviewStatus.APPROVED,
+                "reviewer_reasoning": "trimmed",
+                "reviewer_categories": ["donate"],
+                "_save": "Save",
+            },
+        )
+
+        ev.refresh_from_db()
+        org.refresh_from_db()
+        assert ev.status == ReviewStatus.APPROVED
+        assert ev.reviewer_categories == ["donate"]
+        # The linked org must reflect the reviewer's edit, not the
+        # stale pre-unapproval set.
+        assert list(
+            org.categories.values_list("slug", flat=True),
+        ) == ["donate"]

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -1320,13 +1320,24 @@ class TestReviewerCategoriesPostApprovalSync:
             org.categories.values_list("slug", flat=True),
         ) == ["donate"]
 
-    def test_editing_reviewer_reasoning_alone_does_not_touch_org(
+    def test_unchanged_prefilled_checkboxes_do_not_resync_org(
         self,
         admin_client: Client,
         admin_user: User,
     ) -> None:
-        """Only changes to reviewer_categories should resync — editing
-        reviewer_reasoning must not silently rewrite org categories."""
+        """Out-of-band edits to ``Organization.categories`` survive a
+        form save that leaves the prefilled checkboxes untouched.
+
+        ``reviewer_categories`` is ``NULL`` after the first (bulk or
+        non-form) approval, but the form's ``__init__`` prefills the
+        checkboxes from the AI list so they render as "already
+        checked." If the reviewer submits without toggling any box,
+        ``form.initial`` shadows the ``NULL`` DB value and
+        ``reviewer_categories`` is absent from ``form.changed_data``
+        — so the sync correctly skips. Anything that edited
+        ``org.categories`` outside the admin (a shell fixup, a data
+        migration) is preserved.
+        """
         ev = OrganizationEvaluation.objects.create(
             evaluation_data=_make_evaluation_data(
                 accessibility={"categories": ["donate", "volunteer"]},
@@ -1339,9 +1350,7 @@ class TestReviewerCategoriesPostApprovalSync:
         ev.refresh_from_db()
         org = ev.organization
         assert org is not None
-        # Simulate something having edited org.categories out-of-band
-        # to drift from reviewer_categories — editing the reasoning
-        # field alone must not overwrite that drift.
+        # Simulate the out-of-band drift we want to preserve.
         donate_only = list(
             org.categories.model.objects.filter(slug="donate"),
         )
@@ -1361,9 +1370,6 @@ class TestReviewerCategoriesPostApprovalSync:
 
         ev.refresh_from_db()
         org.refresh_from_db()
-        # reviewer_categories didn't actually change from its initial
-        # (form-prefilled) value of ['donate', 'volunteer'], so the
-        # out-of-band donate-only state on the org is preserved.
         assert list(
             org.categories.values_list("slug", flat=True),
         ) == ["donate"]

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -1,4 +1,3 @@
-import re
 from typing import Any
 from unittest.mock import patch
 
@@ -8,31 +7,15 @@ from django.contrib.auth.models import User
 from django.test import Client
 from django.utils import timezone
 
-from terramedic.organizations.admin import OrganizationEvaluationAdmin
+from terramedic.organizations.admin import (
+    EvaluationReviewForm,
+    OrganizationEvaluationAdmin,
+)
 from terramedic.organizations.models import (
     Organization,
     OrganizationEvaluation,
     ReviewStatus,
 )
-
-
-def _reviewer_category_is_checked(content: str, slug: str) -> bool:
-    """True if the reviewer_categories checkbox for ``slug`` renders checked.
-
-    Order-independent: uses lookahead assertions so the three attributes
-    (``name``, ``value``, ``checked``) may appear in any order within the
-    same ``<input>`` tag. Django's widget renderer doesn't guarantee
-    attribute ordering across versions, and a positional regex would go
-    brittle the next time it changes.
-    """
-    pattern = (
-        rf'<input\b'
-        rf'(?=[^>]*\bname="reviewer_categories")'
-        rf'(?=[^>]*\bvalue="{re.escape(slug)}")'
-        rf'(?=[^>]*\bchecked\b)'
-        rf'[^>]*>'
-    )
-    return re.search(pattern, content) is not None
 
 
 def _make_evaluation_data(**overrides: Any) -> dict[str, Any]:
@@ -1191,21 +1174,17 @@ class TestReviewerCategoriesAdminForm:
 
     def test_detail_form_prefills_checkboxes_with_ai_list(
         self,
-        admin_client: Client,
         pending_evaluation: OrganizationEvaluation,
     ) -> None:
-        """The default fixture's AI list is ['donate', 'volunteer'] —
-        those two should render as checked, 'resource' should not."""
-        response = admin_client.get(
-            f"/admin/organizations/organizationevaluation/"
-            f"{pending_evaluation.pk}/change/",
-        )
-        content = response.content.decode()
-        assert _reviewer_category_is_checked(content, "donate")
-        assert _reviewer_category_is_checked(content, "volunteer")
-        assert not _reviewer_category_is_checked(content, "resource")
-        assert not _reviewer_category_is_checked(content, "career")
-        assert not _reviewer_category_is_checked(content, "everyday")
+        """Initial checkbox state comes from the AI's proposed list.
+
+        Assert against ``form.initial`` directly — the widget's HTML
+        output is a Django-internal detail we don't want to lock in.
+        """
+        form = EvaluationReviewForm(instance=pending_evaluation)
+        assert set(form.initial["reviewer_categories"]) == {
+            "donate", "volunteer",
+        }
 
     def test_submit_with_subset_persists_and_trims_org_categories(
         self,
@@ -1242,10 +1221,7 @@ class TestReviewerCategoriesAdminForm:
             ev.organization.categories.values_list("slug", flat=True),
         ) == ["donate"]
 
-    def test_prefill_uses_saved_override_when_present(
-        self,
-        admin_client: Client,
-    ) -> None:
+    def test_prefill_uses_saved_override_when_present(self) -> None:
         """Once a reviewer has saved an override, reopening the form
         reflects their choice — not the AI's original list."""
         ev = OrganizationEvaluation.objects.create(
@@ -1256,14 +1232,8 @@ class TestReviewerCategoriesAdminForm:
             ),
             reviewer_categories=["donate"],
         )
-        response = admin_client.get(
-            f"/admin/organizations/organizationevaluation/"
-            f"{ev.pk}/change/",
-        )
-        content = response.content.decode()
-        assert _reviewer_category_is_checked(content, "donate")
-        assert not _reviewer_category_is_checked(content, "volunteer")
-        assert not _reviewer_category_is_checked(content, "resource")
+        form = EvaluationReviewForm(instance=ev)
+        assert form.initial["reviewer_categories"] == ["donate"]
 
 
 @pytest.mark.django_db

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -1076,3 +1076,186 @@ class TestCategoryFilter:
         content = response.content.decode()
         assert "Volunteer Corps" in content
         assert "Test Organization" not in content
+
+
+@pytest.mark.django_db
+class TestReviewerCategoriesOverride:
+    """Reviewer can trim the AI's category list before approval.
+
+    The AI tends to over-classify (assigns 3-4 categories when only 1-2
+    actually fit). Before this change, reviewers had to approve the
+    evaluation and then edit the created Organization to remove the
+    spurious categories. Now the reviewer picks the final list up-front,
+    and the post_save signal creates the Organization with only that
+    subset.
+    """
+
+    def test_reviewer_categories_defaults_to_none(self) -> None:
+        """A fresh evaluation has no reviewer override — the AI's list
+        is used on approval."""
+        ev = OrganizationEvaluation.objects.create(
+            evaluation_data=_make_evaluation_data(),
+        )
+        assert ev.reviewer_categories is None
+
+    def test_reviewer_categories_override_trims_ai_list_on_approval(
+        self,
+        admin_user: User,
+    ) -> None:
+        """When reviewer_categories is a subset of the AI's list, only
+        the chosen slugs get assigned to the created Organization."""
+        ev = OrganizationEvaluation.objects.create(
+            evaluation_data=_make_evaluation_data(
+                accessibility={
+                    "categories": ["donate", "volunteer", "resource"],
+                },
+            ),
+            reviewer_categories=["donate"],
+        )
+        ev.status = ReviewStatus.APPROVED
+        ev.reviewer = admin_user
+        ev.reviewed_at = timezone.now()
+        ev.save()
+        ev.refresh_from_db()
+        assert ev.organization is not None
+        assert list(
+            ev.organization.categories.values_list("slug", flat=True),
+        ) == ["donate"]
+
+    def test_reviewer_categories_none_falls_back_to_ai_list(
+        self,
+        admin_user: User,
+    ) -> None:
+        """Leaving reviewer_categories as None preserves the legacy
+        behavior: the AI's accessibility.categories is used verbatim.
+        This is what the bulk-approve path relies on."""
+        ev = OrganizationEvaluation.objects.create(
+            evaluation_data=_make_evaluation_data(
+                accessibility={"categories": ["donate", "volunteer"]},
+            ),
+        )
+        assert ev.reviewer_categories is None
+        ev.status = ReviewStatus.APPROVED
+        ev.reviewer = admin_user
+        ev.reviewed_at = timezone.now()
+        ev.save()
+        ev.refresh_from_db()
+        assert ev.organization is not None
+        assert set(
+            ev.organization.categories.values_list("slug", flat=True),
+        ) == {"donate", "volunteer"}
+
+
+@pytest.mark.django_db
+class TestReviewerCategoriesAdminForm:
+    """The detail-page form exposes per-category checkboxes prefilled
+    with the AI's proposed list so reviewers can uncheck spurious ones
+    before approving."""
+
+    def test_detail_form_renders_category_checkboxes(
+        self,
+        admin_client: Client,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        response = admin_client.get(
+            f"/admin/organizations/organizationevaluation/"
+            f"{pending_evaluation.pk}/change/",
+        )
+        content = response.content.decode()
+        assert 'name="reviewer_categories"' in content
+        assert 'value="donate"' in content
+        assert 'value="volunteer"' in content
+        assert 'value="resource"' in content
+
+    def test_detail_form_prefills_checkboxes_with_ai_list(
+        self,
+        admin_client: Client,
+        pending_evaluation: OrganizationEvaluation,
+    ) -> None:
+        """The default fixture's AI list is ['donate', 'volunteer'] —
+        those two should render as checked, 'resource' should not."""
+        import re
+        response = admin_client.get(
+            f"/admin/organizations/organizationevaluation/"
+            f"{pending_evaluation.pk}/change/",
+        )
+        content = response.content.decode()
+        # Django's CheckboxSelectMultiple emits each option as its own
+        # <input> — match on the surrounding fragment so we don't tie
+        # the assertion to attribute ordering.
+        def checked(slug: str) -> bool:
+            pattern = (
+                rf'<input[^>]*name="reviewer_categories"[^>]*'
+                rf'value="{slug}"[^>]*checked'
+            )
+            return re.search(pattern, content) is not None
+        assert checked("donate")
+        assert checked("volunteer")
+        assert not checked("resource")
+        assert not checked("career")
+        assert not checked("everyday")
+
+    def test_submit_with_subset_persists_and_trims_org_categories(
+        self,
+        admin_client: Client,
+    ) -> None:
+        """Reviewer unchecks 'volunteer' and 'resource', approves —
+        persisted override is ['donate'] and the Organization gets
+        only that slug."""
+        ev = OrganizationEvaluation.objects.create(
+            evaluation_data=_make_evaluation_data(
+                accessibility={
+                    "categories": ["donate", "volunteer", "resource"],
+                },
+            ),
+        )
+        url = (
+            f"/admin/organizations/organizationevaluation/"
+            f"{ev.pk}/change/"
+        )
+        response = admin_client.post(
+            url,
+            {
+                "status": ReviewStatus.APPROVED,
+                "reviewer_reasoning": "",
+                "reviewer_categories": ["donate"],
+                "_save": "Save",
+            },
+        )
+        assert response.status_code == 302
+        ev.refresh_from_db()
+        assert ev.reviewer_categories == ["donate"]
+        assert ev.organization is not None
+        assert list(
+            ev.organization.categories.values_list("slug", flat=True),
+        ) == ["donate"]
+
+    def test_prefill_uses_saved_override_when_present(
+        self,
+        admin_client: Client,
+    ) -> None:
+        """Once a reviewer has saved an override, reopening the form
+        reflects their choice — not the AI's original list."""
+        import re
+        ev = OrganizationEvaluation.objects.create(
+            evaluation_data=_make_evaluation_data(
+                accessibility={
+                    "categories": ["donate", "volunteer", "resource"],
+                },
+            ),
+            reviewer_categories=["donate"],
+        )
+        response = admin_client.get(
+            f"/admin/organizations/organizationevaluation/"
+            f"{ev.pk}/change/",
+        )
+        content = response.content.decode()
+        def checked(slug: str) -> bool:
+            pattern = (
+                rf'<input[^>]*name="reviewer_categories"[^>]*'
+                rf'value="{slug}"[^>]*checked'
+            )
+            return re.search(pattern, content) is not None
+        assert checked("donate")
+        assert not checked("volunteer")
+        assert not checked("resource")

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -1264,3 +1264,106 @@ class TestReviewerCategoriesAdminForm:
         assert _reviewer_category_is_checked(content, "donate")
         assert not _reviewer_category_is_checked(content, "volunteer")
         assert not _reviewer_category_is_checked(content, "resource")
+
+
+@pytest.mark.django_db
+class TestReviewerCategoriesPostApprovalSync:
+    """Edits to reviewer_categories on an already-approved evaluation
+    must flow through to the linked Organization.
+
+    The post_save signal only creates or reactivates an Organization on
+    the APPROVED transition; it doesn't touch categories on subsequent
+    saves. Without an explicit sync, an admin editing
+    reviewer_categories after approval would see the evaluation form
+    disagree with the live Organization state.
+    """
+
+    def test_changing_reviewer_categories_after_approval_updates_org(
+        self,
+        admin_client: Client,
+        admin_user: User,
+    ) -> None:
+        ev = OrganizationEvaluation.objects.create(
+            evaluation_data=_make_evaluation_data(
+                accessibility={
+                    "categories": ["donate", "volunteer", "resource"],
+                },
+            ),
+        )
+        ev.status = ReviewStatus.APPROVED
+        ev.reviewer = admin_user
+        ev.reviewed_at = timezone.now()
+        ev.save()
+        ev.refresh_from_db()
+        org = ev.organization
+        assert org is not None
+        assert set(
+            org.categories.values_list("slug", flat=True),
+        ) == {"donate", "volunteer", "resource"}
+
+        response = admin_client.post(
+            f"/admin/organizations/organizationevaluation/"
+            f"{ev.pk}/change/",
+            {
+                "status": ReviewStatus.APPROVED,
+                "reviewer_reasoning": "",
+                "reviewer_categories": ["donate"],
+                "_save": "Save",
+            },
+        )
+        assert response.status_code == 302
+
+        ev.refresh_from_db()
+        org.refresh_from_db()
+        assert ev.reviewer_categories == ["donate"]
+        assert list(
+            org.categories.values_list("slug", flat=True),
+        ) == ["donate"]
+
+    def test_editing_reviewer_reasoning_alone_does_not_touch_org(
+        self,
+        admin_client: Client,
+        admin_user: User,
+    ) -> None:
+        """Only changes to reviewer_categories should resync — editing
+        reviewer_reasoning must not silently rewrite org categories."""
+        ev = OrganizationEvaluation.objects.create(
+            evaluation_data=_make_evaluation_data(
+                accessibility={"categories": ["donate", "volunteer"]},
+            ),
+        )
+        ev.status = ReviewStatus.APPROVED
+        ev.reviewer = admin_user
+        ev.reviewed_at = timezone.now()
+        ev.save()
+        ev.refresh_from_db()
+        org = ev.organization
+        assert org is not None
+        # Simulate something having edited org.categories out-of-band
+        # to drift from reviewer_categories — editing the reasoning
+        # field alone must not overwrite that drift.
+        donate_only = list(
+            org.categories.model.objects.filter(slug="donate"),
+        )
+        org.categories.set(donate_only)
+
+        response = admin_client.post(
+            f"/admin/organizations/organizationevaluation/"
+            f"{ev.pk}/change/",
+            {
+                "status": ReviewStatus.APPROVED,
+                "reviewer_reasoning": "just clarifying",
+                "reviewer_categories": ["donate", "volunteer"],
+                "_save": "Save",
+            },
+        )
+        assert response.status_code == 302
+
+        ev.refresh_from_db()
+        org.refresh_from_db()
+        # reviewer_categories didn't actually change from its initial
+        # (form-prefilled) value of ['donate', 'volunteer'], so the
+        # out-of-band donate-only state on the org is preserved.
+        assert list(
+            org.categories.values_list("slug", flat=True),
+        ) == ["donate"]

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -1080,14 +1080,16 @@ class TestCategoryFilter:
 
 @pytest.mark.django_db
 class TestReviewerCategoriesOverride:
-    """Reviewer can trim the AI's category list before approval.
+    """Reviewer can adjust the AI's category list before approval.
 
-    The AI tends to over-classify (assigns 3-4 categories when only 1-2
-    actually fit). Before this change, reviewers had to approve the
-    evaluation and then edit the created Organization to remove the
-    spurious categories. Now the reviewer picks the final list up-front,
-    and the post_save signal creates the Organization with only that
-    subset.
+    The override works in either direction: trim a category the AI
+    over-assigned, or add one the AI missed. The common case is trimming
+    — the AI tends to over-classify (assigning 3-4 categories when only
+    1-2 fit) — but the mechanism isn't restricted to subsets of the AI's
+    list. Before this change, reviewers had to approve the evaluation
+    and then edit the created Organization; now the reviewer picks the
+    final list up-front and the post_save signal creates the
+    Organization with exactly that set.
     """
 
     def test_reviewer_categories_defaults_to_none(self) -> None:

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 from unittest.mock import patch
 
@@ -13,6 +14,25 @@ from terramedic.organizations.models import (
     OrganizationEvaluation,
     ReviewStatus,
 )
+
+
+def _reviewer_category_is_checked(content: str, slug: str) -> bool:
+    """True if the reviewer_categories checkbox for ``slug`` renders checked.
+
+    Order-independent: uses lookahead assertions so the three attributes
+    (``name``, ``value``, ``checked``) may appear in any order within the
+    same ``<input>`` tag. Django's widget renderer doesn't guarantee
+    attribute ordering across versions, and a positional regex would go
+    brittle the next time it changes.
+    """
+    pattern = (
+        rf'<input\b'
+        rf'(?=[^>]*\bname="reviewer_categories")'
+        rf'(?=[^>]*\bvalue="{re.escape(slug)}")'
+        rf'(?=[^>]*\bchecked\b)'
+        rf'[^>]*>'
+    )
+    return re.search(pattern, content) is not None
 
 
 def _make_evaluation_data(**overrides: Any) -> dict[str, Any]:
@@ -1176,26 +1196,16 @@ class TestReviewerCategoriesAdminForm:
     ) -> None:
         """The default fixture's AI list is ['donate', 'volunteer'] —
         those two should render as checked, 'resource' should not."""
-        import re
         response = admin_client.get(
             f"/admin/organizations/organizationevaluation/"
             f"{pending_evaluation.pk}/change/",
         )
         content = response.content.decode()
-        # Django's CheckboxSelectMultiple emits each option as its own
-        # <input> — match on the surrounding fragment so we don't tie
-        # the assertion to attribute ordering.
-        def checked(slug: str) -> bool:
-            pattern = (
-                rf'<input[^>]*name="reviewer_categories"[^>]*'
-                rf'value="{slug}"[^>]*checked'
-            )
-            return re.search(pattern, content) is not None
-        assert checked("donate")
-        assert checked("volunteer")
-        assert not checked("resource")
-        assert not checked("career")
-        assert not checked("everyday")
+        assert _reviewer_category_is_checked(content, "donate")
+        assert _reviewer_category_is_checked(content, "volunteer")
+        assert not _reviewer_category_is_checked(content, "resource")
+        assert not _reviewer_category_is_checked(content, "career")
+        assert not _reviewer_category_is_checked(content, "everyday")
 
     def test_submit_with_subset_persists_and_trims_org_categories(
         self,
@@ -1238,7 +1248,6 @@ class TestReviewerCategoriesAdminForm:
     ) -> None:
         """Once a reviewer has saved an override, reopening the form
         reflects their choice — not the AI's original list."""
-        import re
         ev = OrganizationEvaluation.objects.create(
             evaluation_data=_make_evaluation_data(
                 accessibility={
@@ -1252,12 +1261,6 @@ class TestReviewerCategoriesAdminForm:
             f"{ev.pk}/change/",
         )
         content = response.content.decode()
-        def checked(slug: str) -> bool:
-            pattern = (
-                rf'<input[^>]*name="reviewer_categories"[^>]*'
-                rf'value="{slug}"[^>]*checked'
-            )
-            return re.search(pattern, content) is not None
-        assert checked("donate")
-        assert not checked("volunteer")
-        assert not checked("resource")
+        assert _reviewer_category_is_checked(content, "donate")
+        assert not _reviewer_category_is_checked(content, "volunteer")
+        assert not _reviewer_category_is_checked(content, "resource")

--- a/backend/terramedic/organizations/tests/test_evaluation_admin.py
+++ b/backend/terramedic/organizations/tests/test_evaluation_admin.py
@@ -1290,23 +1290,27 @@ class TestReviewerCategoriesPostApprovalSync:
             org.categories.values_list("slug", flat=True),
         ) == ["donate"]
 
-    def test_unchanged_prefilled_checkboxes_do_not_resync_org(
+    def test_noop_save_preserves_null_and_resyncs_org_to_ai_list(
         self,
         admin_client: Client,
         admin_user: User,
     ) -> None:
-        """Out-of-band edits to ``Organization.categories`` survive a
-        form save that leaves the prefilled checkboxes untouched.
+        """A no-op form save preserves ``reviewer_categories=NULL``
+        and resyncs the linked org to the AI list.
 
-        ``reviewer_categories`` is ``NULL`` after the first (bulk or
-        non-form) approval, but the form's ``__init__`` prefills the
-        checkboxes from the AI list so they render as "already
-        checked." If the reviewer submits without toggling any box,
-        ``form.initial`` shadows the ``NULL`` DB value and
-        ``reviewer_categories`` is absent from ``form.changed_data``
-        — so the sync correctly skips. Anything that edited
-        ``org.categories`` outside the admin (a shell fixup, a data
-        migration) is preserved.
+        The form's ``__init__`` prefills the checkboxes from the AI
+        list when ``reviewer_categories`` is ``NULL``. If the reviewer
+        clicks Save without toggling a box, ``clean_reviewer_categories``
+        detects that the submission equals the AI fallback and returns
+        ``None`` — so the DB stays ``NULL`` (no silent promotion to an
+        explicit override) and the evaluation continues to track the
+        AI list even if the list later evolves.
+
+        The reviewer's Save is still authoritative, though: any
+        out-of-band drift on ``org.categories`` is overwritten to
+        match the evaluation's resolved state. From the admin's point
+        of view the checkboxes are what's stored — showing the AI
+        defaults and saving makes the linked org match.
         """
         ev = OrganizationEvaluation.objects.create(
             evaluation_data=_make_evaluation_data(
@@ -1320,7 +1324,7 @@ class TestReviewerCategoriesPostApprovalSync:
         ev.refresh_from_db()
         org = ev.organization
         assert org is not None
-        # Simulate the out-of-band drift we want to preserve.
+        # Simulate out-of-band drift on the linked org.
         donate_only = list(
             org.categories.model.objects.filter(slug="donate"),
         )
@@ -1340,9 +1344,14 @@ class TestReviewerCategoriesPostApprovalSync:
 
         ev.refresh_from_db()
         org.refresh_from_db()
-        assert list(
+        # NULL preserved — the reviewer didn't express an override,
+        # they just confirmed the AI defaults.
+        assert ev.reviewer_categories is None
+        # Org resynced to match the evaluation's effective categories
+        # (the AI list), not the out-of-band drifted state.
+        assert set(
             org.categories.values_list("slug", flat=True),
-        ) == ["donate"]
+        ) == {"donate", "volunteer"}
 
     def test_reapproval_with_category_edit_syncs_org(
         self,


### PR DESCRIPTION
## Summary

Two independent prompt-quality improvements for the curation pipeline, plus an admin-side escape hatch for reviewers. All three ship under a single `PROMPT_VERSION` bump to `2026.04.10`.

### 1. Category assignment discipline
- New "Assignment discipline" section in the prompt: anchors the model on 1-2 categories as typical, with per-slug anti-patterns and a "when in doubt, leave the category off" default.
- New `OrganizationEvaluation.reviewer_categories` JSONField. Surfaced on the evaluation detail form as per-category checkboxes prefilled with the AI's proposed list; reviewer's selection persists and feeds into the created Organization via `create_org_from_evaluation`. Bulk-approve and pre-existing evaluations fall back to the AI's `accessibility.categories` unchanged.
- Editing `reviewer_categories` on an already-approved evaluation resyncs the linked Organization's categories (the post_save signal only handles the initial APPROVED transition, so a dedicated sync in `save_model` keeps the form and the live org from drifting).
- Motivation: evaluating 15 orgs surfaced a consistent pattern where the AI assigned 3-4 categories to orgs that only fit 1-2.

### 2. Description length guidelines
- New "Description guidelines" section in the prompt: targets **one to two sentences, roughly 120-180 characters**, with a 200-character ceiling. Includes concrete anti-patterns (filler phrases, mission-statement padding).
- Motivation: `OrganizationCard` renders `description` verbatim with no truncation, so uneven lengths show up as visible jitter on listing pages like `/volunteer`.

## Test plan

- [x] `SECRET_KEY=test poetry run pytest` — 577 passed (prompt-regression tests for both new sections; admin tests covering reviewer override, post-approval sync, and prefill behavior)
- [x] `poetry run ruff check .` — clean
- [ ] Apply migration `0020_add_reviewer_categories` in dev, open a pending evaluation in the admin, verify checkboxes render prefilled with the AI's categories
- [ ] Approve with a subset of categories; edit `reviewer_categories` again post-approval; verify the linked Organization's categories update
- [ ] Re-run the batch of 15 orgs on the new prompt version; spot-check that category counts average 1-2 and that descriptions cluster around 120-180 chars on `/volunteer` cards

## Follow-ups

- If descriptions still drift long despite the prompt, consider a hard `maxLength: 200` in `schema.json` as a validator backstop.
- If over-classification persists, consider a structured `category_justifications` schema field so reviewers can see *why* each category was proposed.