### PR TITLE
feat(organizations): re-evaluation workflow (list + generate + load)

### DIFF
--- a/backend/curation/evaluate.py
+++ b/backend/curation/evaluate.py
@@ -511,6 +511,11 @@ def evaluate_org(
     result["evaluated_by"] = model
     result["prompt_version"] = PROMPT_VERSION
     result["duration_ms"] = int(elapsed * 1000)
+    # Preserve the nominated URL verbatim. The model tends to
+    # normalize ``website_url`` to the domain root, which would
+    # collapse subpages (local chapter pages, specific program
+    # landing pages) into a single Organization record.
+    result.setdefault("org_metadata", {})["website_url"] = url
 
     _validate_against_schema(result, source="Output")
 
@@ -630,6 +635,11 @@ def evaluate_org_via_claude_code(
     data["prompt_version"] = PROMPT_VERSION
     if duration_ms is not None:
         data["duration_ms"] = duration_ms
+    # Preserve the nominated URL verbatim. The model tends to
+    # normalize ``website_url`` to the domain root, which would
+    # collapse subpages (local chapter pages, specific program
+    # landing pages) into a single Organization record.
+    data.setdefault("org_metadata", {})["website_url"] = url
 
     _validate_against_schema(data, source="Claude Code output")
     return data

--- a/backend/curation/evaluate.py
+++ b/backend/curation/evaluate.py
@@ -18,6 +18,7 @@ import logging
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -306,11 +307,20 @@ def _strip_nulls(obj: Any) -> None:
 def _build_user_message(
     url: str,
     categories: list[str] | None = None,
-) -> str:
-    """Fetch the org's website and build the user message for the model."""
+) -> tuple[str, int]:
+    """Fetch the org's website and build the user message for the model.
+
+    Returns ``(message, pages_fetched)`` — the count tracks every page
+    the curation layer attempted to fetch via ``httpx`` (homepage +
+    subpages) regardless of whether each fetch succeeded, so it lines
+    up 1:1 with the ``Fetching ...`` lines written to stderr. This is
+    distinct from any ``server_tool_use`` web fetches Claude might do
+    on top; callers log both.
+    """
     import httpx
 
     print(f"Fetching {url} ...", file=sys.stderr)
+    pages_fetched = 1
     homepage_html = None
     try:
         resp = httpx.get(
@@ -329,6 +339,7 @@ def _build_user_message(
     subpage_texts: list[str] = []
     if homepage_html:
         subpage_urls = _extract_subpage_urls(homepage_html, url)
+        pages_fetched += len(subpage_urls)
         for sub_url in subpage_urls:
             print(f"  Fetching {sub_url} ...", file=sys.stderr)
             sub_text = _fetch_page_text(sub_url)
@@ -363,7 +374,7 @@ def _build_user_message(
             "Evaluate based on your training data and flag "
             "that the website was unreachable in curator_notes.flags."
         )
-    return message
+    return message, pages_fetched
 
 
 def _validate_against_schema(
@@ -425,8 +436,11 @@ def evaluate_org(
             sys.exit(1)
         client = Anthropic(api_key=api_key)
 
-    user_content = _build_user_message(url, categories=categories)
+    user_content, pages_fetched = _build_user_message(
+        url, categories=categories,
+    )
 
+    t0 = time.monotonic()
     response = client.messages.create(
         model=model,
         max_tokens=4096,
@@ -463,15 +477,23 @@ def evaluate_org(
         elif block_type == "server_tool_use":
             search_count += 1
 
+    elapsed = time.monotonic() - t0
     usage = getattr(response, "usage", None)
+    # ``pages_fetched`` counts homepage + subpages the curation layer
+    # pulled inline via httpx. ``server_searches`` counts the
+    # Claude-side web_search tool calls. They're separate cost
+    # drivers, so log both.
     logger.info(
-        "eval usage url=%s input=%s output=%s "
-        "cache_read=%s cache_creation=%s searches=%s",
+        "eval usage url=%s elapsed_s=%.1f input=%s output=%s "
+        "cache_read=%s cache_creation=%s pages_fetched=%s "
+        "server_searches=%s",
         url,
+        elapsed,
         getattr(usage, "input_tokens", None),
         getattr(usage, "output_tokens", None),
         getattr(usage, "cache_read_input_tokens", None),
         getattr(usage, "cache_creation_input_tokens", None),
+        pages_fetched,
         search_count,
     )
 
@@ -488,6 +510,7 @@ def evaluate_org(
     )
     result["evaluated_by"] = model
     result["prompt_version"] = PROMPT_VERSION
+    result["duration_ms"] = int(elapsed * 1000)
 
     _validate_against_schema(result, source="Output")
 
@@ -495,14 +518,17 @@ def evaluate_org(
 
 
 def _invoke_claude_cli(
-    cmd: list[str], timeout: int, url: str,
-) -> str:
-    """Run the ``claude`` CLI and return the model's text response.
+    cmd: list[str], timeout: int, url: str, pages_fetched: int = 0,
+) -> tuple[str, int | None]:
+    """Run the ``claude`` CLI and return ``(text, duration_ms)``.
 
-    Handles exit code, JSON envelope parsing, ``is_error`` handling,
-    and per-call usage logging. Raises ``RuntimeError`` on non-zero
-    exit or ``is_error: true``; ``ValueError`` on malformed stdout or
-    missing ``result`` field.
+    ``duration_ms`` is wall-clock for the whole call including tool
+    turns, lifted from the CLI envelope so callers can persist it on
+    the evaluation record without re-measuring. Handles exit code,
+    JSON envelope parsing, ``is_error`` handling, and per-call usage
+    logging. Raises ``RuntimeError`` on non-zero exit or
+    ``is_error: true``; ``ValueError`` on malformed stdout or missing
+    ``result`` field.
     """
     proc = subprocess.run(
         cmd,
@@ -540,15 +566,24 @@ def _invoke_claude_cli(
     # total_cost_usd is 0 on Max subscriptions (no per-token billing);
     # kept for parity with the API-path usage log so the two sources
     # can be grepped the same way.
+    # ``duration_ms`` is wall-clock for the whole call including tool
+    # turns; ``duration_api_ms`` is just Anthropic API time. The gap
+    # between them is where WebFetch / WebSearch latency lives, so
+    # log both when diagnosing slow evaluations.
     logger.info(
-        "eval via claude-code url=%s cost_usd=%s "
-        "searches=%s fetches=%s",
+        "eval via claude-code url=%s duration_ms=%s duration_api_ms=%s "
+        "cost_usd=%s pages_fetched=%s server_searches=%s "
+        "server_fetches=%s",
         url,
+        envelope.get("duration_ms"),
+        envelope.get("duration_api_ms"),
         envelope.get("total_cost_usd"),
+        pages_fetched,
         tool_use.get("web_search_requests"),
         tool_use.get("web_fetch_requests"),
     )
-    return text
+    duration_ms = envelope.get("duration_ms")
+    return text, duration_ms if isinstance(duration_ms, int) else None
 
 
 def evaluate_org_via_claude_code(
@@ -569,7 +604,9 @@ def evaluate_org_via_claude_code(
     paths are distinguishable in stored records.
     """
     _validate_url(url)
-    user_content = _build_user_message(url, categories=categories)
+    user_content, pages_fetched = _build_user_message(
+        url, categories=categories,
+    )
 
     cmd = [
         "claude",
@@ -580,7 +617,9 @@ def evaluate_org_via_claude_code(
         "--permission-mode", "dontAsk",
         "--model", model,
     ]
-    text = _invoke_claude_cli(cmd, timeout=timeout, url=url)
+    text, duration_ms = _invoke_claude_cli(
+        cmd, timeout=timeout, url=url, pages_fetched=pages_fetched,
+    )
 
     data = _extract_json(text)
     _clean_response(data)
@@ -589,6 +628,8 @@ def evaluate_org_via_claude_code(
     )
     data["evaluated_by"] = f"claude-code:{model}"
     data["prompt_version"] = PROMPT_VERSION
+    if duration_ms is not None:
+        data["duration_ms"] = duration_ms
 
     _validate_against_schema(data, source="Claude Code output")
     return data

--- a/backend/curation/prompt.py
+++ b/backend/curation/prompt.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 # Bump this version whenever SYSTEM_PROMPT is modified.
 # Format: YYYY.MM.N where N resets to 1 each month.
-PROMPT_VERSION: str = "2026.04.10"
+PROMPT_VERSION: str = "2026.04.11"
 
 # Fields injected programmatically by evaluate.py after the model responds.
 # They are stripped from the schema before embedding in the prompt so the
@@ -83,6 +83,14 @@ in..."*, or *"mission is to..."* — they eat characters without \
 adding information.
 - Don't pad short orgs to hit the target; concision beats filler. \
 Don't truncate mid-thought to fit either — rewrite instead.
+- **Describe what was nominated, not the parent site.** If the URL \
+points to a subpage (e.g. ``/solutions/``, ``/chapters/denver``, a \
+specific program landing page), the description must cover that \
+subpage's scope — the hub, tool, chapter, or program — not a \
+generic summary of the parent organization. Example: for \
+``yaleclimateconnections.org/solutions/``, describe the Solutions \
+Hub's practical guides and how-to content, not YCC's broader \
+journalism operation.
 
 ## Nomination categories
 

--- a/backend/curation/prompt.py
+++ b/backend/curation/prompt.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 # Bump this version whenever SYSTEM_PROMPT is modified.
 # Format: YYYY.MM.N where N resets to 1 each month.
-PROMPT_VERSION: str = "2026.04.11"
+PROMPT_VERSION: str = "2026.04.12"
 
 # Fields injected programmatically by evaluate.py after the model responds.
 # They are stripped from the schema before embedding in the prompt so the
@@ -90,7 +90,10 @@ subpage's scope — the hub, tool, chapter, or program — not a \
 generic summary of the parent organization. Example: for \
 ``yaleclimateconnections.org/solutions/``, describe the Solutions \
 Hub's practical guides and how-to content, not YCC's broader \
-journalism operation.
+journalism operation. If the nominated subpage links out to \
+deeper pages (e.g. individual guides under a hub, upcoming \
+events on a chapter page), follow those links when they help you \
+characterize the subpage's actual scope and activities.
 
 ## Nomination categories
 

--- a/backend/curation/prompt.py
+++ b/backend/curation/prompt.py
@@ -16,6 +16,7 @@ _PROGRAMMATIC_FIELDS = (
     "evaluated_at",
     "evaluated_by",
     "prompt_version",
+    "duration_ms",
     "evaluation_history",
 )
 

--- a/backend/curation/schema.json
+++ b/backend/curation/schema.json
@@ -356,6 +356,11 @@
       "type": "string",
       "description": "Version of the curation prompt used for this evaluation."
     },
+    "duration_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Wall-clock time, in milliseconds, for the model call (including any server-side tool turns). Omitted if not measurable."
+    },
     "evaluation_history": {
       "type": "array",
       "description": "Prior evaluations of this organization, preserved when re-evaluating with a new prompt version.",

--- a/backend/curation/tests/test_evaluate.py
+++ b/backend/curation/tests/test_evaluate.py
@@ -337,7 +337,7 @@ class TestEvaluateOrg:
         assert "input=1234" in log_text
         assert "output=567" in log_text
         assert "cache_read=890" in log_text
-        assert "searches=2" in log_text
+        assert "server_searches=2" in log_text
 
     def test_extracts_text_from_mixed_content_blocks(
         self, monkeypatch: pytest.MonkeyPatch,
@@ -473,6 +473,8 @@ class TestEvaluateOrgViaClaudeCode:
             "is_error": is_error,
             "result": json.dumps(payload),
             "total_cost_usd": 0.001,
+            "duration_ms": 12345,
+            "duration_api_ms": 6789,
             "usage": {
                 "input_tokens": 100,
                 "output_tokens": 50,
@@ -493,7 +495,7 @@ class TestEvaluateOrgViaClaudeCode:
     ) -> None:
         monkeypatch.setattr(
             "curation.evaluate._build_user_message",
-            lambda *_a, **_kw: "fake user message",
+            lambda *_a, **_kw: ("fake user message", 0),
         )
 
     def test_invokes_claude_cli_with_expected_flags(
@@ -557,6 +559,32 @@ class TestEvaluateOrgViaClaudeCode:
         )
 
         assert result["org_metadata"]["name"] == "Test Org"
+
+    def test_stamps_duration_ms_from_envelope(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``duration_ms`` from the CLI envelope must land on the
+        stored evaluation so it's queryable later without grepping
+        logs."""
+        from curation.evaluate import evaluate_org_via_claude_code
+
+        self._patch_build_user_message(monkeypatch)
+        eval_payload = _make_valid_evaluation()
+        del eval_payload["evaluated_at"]
+        del eval_payload["evaluated_by"]
+
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *_a, **_kw: self._fake_subprocess_result(eval_payload),
+        )
+
+        result = evaluate_org_via_claude_code(
+            "https://example.org",
+            model="sonnet",
+        )
+
+        # _fake_subprocess_result stamps duration_ms=12345.
+        assert result["duration_ms"] == 12345
 
     def test_stamps_evaluated_by_with_claude_code_prefix(
         self, monkeypatch: pytest.MonkeyPatch,
@@ -973,7 +1001,7 @@ class TestBuildUserMessage:
             return resp
 
         monkeypatch.setattr(_httpx, "get", fake_get)
-        message = _build_user_message("https://example.org")
+        message, _ = _build_user_message("https://example.org")
         today = datetime.datetime.now(tz=datetime.UTC).date().isoformat()  # type: ignore[attr-defined]
         assert f"Today's date is {today}" in message
 
@@ -990,7 +1018,7 @@ class TestBuildUserMessage:
             return resp
 
         monkeypatch.setattr(_httpx, "get", fake_get)
-        message = _build_user_message(
+        message, _ = _build_user_message(
             "https://example.org",
             categories=["donate", "resource"],
         )
@@ -1011,7 +1039,7 @@ class TestBuildUserMessage:
             return resp
 
         monkeypatch.setattr(_httpx, "get", fake_get)
-        message = _build_user_message("https://example.org")
+        message, _ = _build_user_message("https://example.org")
         assert "nominated" not in message.lower()
 
 

--- a/backend/curation/tests/test_evaluate.py
+++ b/backend/curation/tests/test_evaluate.py
@@ -586,6 +586,40 @@ class TestEvaluateOrgViaClaudeCode:
         # _fake_subprocess_result stamps duration_ms=12345.
         assert result["duration_ms"] == 12345
 
+    def test_preserves_nominated_url_when_model_normalizes_to_root(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If a curator nominates a subpage (e.g. a local chapter or
+        a specific program page), the eval must stay bound to that
+        subpage. The model tends to normalize ``website_url`` to the
+        domain root, which would collapse distinct chapter pages into
+        a single Organization record. The nominated URL wins."""
+        from curation.evaluate import evaluate_org_via_claude_code
+
+        self._patch_build_user_message(monkeypatch)
+        eval_payload = _make_valid_evaluation()
+        del eval_payload["evaluated_at"]
+        del eval_payload["evaluated_by"]
+        # Model normalized to the domain root.
+        eval_payload["org_metadata"]["website_url"] = (
+            "https://yaleclimateconnections.org"
+        )
+
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *_a, **_kw: self._fake_subprocess_result(eval_payload),
+        )
+
+        result = evaluate_org_via_claude_code(
+            "https://yaleclimateconnections.org/solutions/",
+            model="sonnet",
+        )
+
+        assert (
+            result["org_metadata"]["website_url"]
+            == "https://yaleclimateconnections.org/solutions/"
+        )
+
     def test_stamps_evaluated_by_with_claude_code_prefix(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:

--- a/backend/terramedic/organizations/management/commands/evaluate_urls_to_fixtures.py
+++ b/backend/terramedic/organizations/management/commands/evaluate_urls_to_fixtures.py
@@ -148,14 +148,19 @@ class Command(BaseCommand):
 def _read_urls(path: Path) -> list[str]:
     """Read URLs from a plain-text file, one per line.
 
-    Blank lines and lines whose first non-space character is ``#`` are
-    skipped so the file can carry human-readable comments without
-    confusing downstream processing.
+    Skips blank lines, lines whose first non-space character is ``#``,
+    and anything that doesn't start with ``http://`` or ``https://``.
+    The last rule lets a curator redirect ``zappa manage ...
+    "list_reevaluation_candidates"`` output straight to a file — the
+    Lambda log wrapping (``START``, ``END``, ``REPORT``, Zappa upgrade
+    notice, etc.) drops out automatically without a hand-grep step.
     """
     urls: list[str] = []
     for raw in path.read_text().splitlines():
         line = raw.strip()
         if not line or line.startswith("#"):
+            continue
+        if not line.startswith(("http://", "https://")):
             continue
         urls.append(line)
     return urls

--- a/backend/terramedic/organizations/management/commands/evaluate_urls_to_fixtures.py
+++ b/backend/terramedic/organizations/management/commands/evaluate_urls_to_fixtures.py
@@ -1,0 +1,161 @@
+"""Run ``evaluate_org_via_claude_code`` over a list of URLs and write
+the results as a Django fixture file suitable for ``loaddata``.
+
+This is the local-only half of the re-evaluation workflow:
+
+1. Get URLs from the DB in the private subnet (remote):
+   ``zappa manage <env> "list_reevaluation_candidates" > urls.txt``
+2. Evaluate locally via the authenticated ``claude`` CLI (this
+   command) — writes ``out.json``, no DB access needed.
+3. Ship the fixture back (``zappa update`` to package it, or copy
+   to S3 / the Zappa working tree) and load with
+   ``zappa manage <env> "loaddata out.json"``.
+
+Requires the shell to be logged into Claude Code (``claude auth``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from argparse import ArgumentParser
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError
+
+from curation.evaluate import evaluate_org_via_claude_code
+from terramedic.organizations.models import ReviewStatus
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Evaluate a list of URLs via the local claude CLI and write a"
+        " Django fixture JSON that loaddata can consume into"
+        " OrganizationEvaluation rows with status=PENDING."
+    )
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "urls_file",
+            help="Path to a file with one URL per line. Blank lines"
+                 " and lines starting with # are ignored.",
+        )
+        parser.add_argument(
+            "--out",
+            help="Path to write the fixture JSON file. Required"
+                 " unless --dry-run is set.",
+        )
+        parser.add_argument(
+            "--model",
+            default="sonnet",
+            help="Claude Code model alias (default: sonnet).",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="List URLs that would be evaluated without calling"
+                 " the claude CLI or writing the fixture file.",
+        )
+
+    def handle(self, *_args: Any, **options: Any) -> None:
+        urls_file = Path(str(options["urls_file"]))
+        dry_run: bool = options["dry_run"]
+        model = str(options["model"])
+        out_arg = options.get("out")
+        out_path = Path(str(out_arg)) if out_arg else None
+
+        if not urls_file.is_file():
+            raise CommandError(f"{urls_file} is not a file.")
+        if not dry_run and out_path is None:
+            raise CommandError("--out is required unless --dry-run.")
+
+        urls = _read_urls(urls_file)
+
+        if dry_run:
+            self.stdout.write(
+                f"[dry-run] Would evaluate {len(urls)} URL(s) via"
+                " claude-code:",
+            )
+            for url in urls:
+                self.stdout.write(f"  {url}")
+            self.stdout.write(
+                "[dry-run] No claude CLI calls made, no fixture"
+                " written.",
+            )
+            return
+
+        self.stdout.write(
+            f"Evaluating {len(urls)} URL(s) via claude-code...",
+        )
+        fixtures: list[dict[str, Any]] = []
+        for url in urls:
+            fixture = self._evaluate_one(url, model=model)
+            if fixture is not None:
+                fixtures.append(fixture)
+
+        assert out_path is not None  # narrowed by the guard above
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(fixtures, indent=2) + "\n")
+        self.stdout.write(
+            f"Wrote {len(fixtures)} fixture row(s) to {out_path}.",
+        )
+
+    def _evaluate_one(
+        self,
+        url: str,
+        *,
+        model: str,
+    ) -> dict[str, Any] | None:
+        self.stdout.write(f"  {url} ...")
+        try:
+            data = evaluate_org_via_claude_code(url, model=model)
+        except Exception as exc:  # noqa: BLE001
+            # Any failure — CLI timeout, schema validation,
+            # subprocess error — is reported and skipped so the
+            # rest of the batch continues.
+            self.stderr.write(f"    FAILED {url}: {exc}")
+            logger.exception(
+                "evaluate_org_via_claude_code failed for %s", url,
+            )
+            return None
+
+        curator_notes = data.get("curator_notes") or {}
+        # loaddata bypasses auto_now_add, so created_at must appear
+        # in the fixture or the NOT NULL constraint blocks the insert.
+        # ISO 8601 UTC is what Django's date/time parser expects.
+        now = datetime.now(tz=UTC).isoformat()
+        return {
+            "model": "organizations.organizationevaluation",
+            "fields": {
+                "evaluation_data": data,
+                "ai_model": data.get("evaluated_by", ""),
+                "ai_recommendation": curator_notes.get(
+                    "recommendation", "",
+                ),
+                "ai_confidence": curator_notes.get("confidence"),
+                "status": ReviewStatus.PENDING,
+                "reviewer_categories": None,
+                "reviewer_reasoning": "",
+                "created_at": now,
+            },
+        }
+
+
+def _read_urls(path: Path) -> list[str]:
+    """Read URLs from a plain-text file, one per line.
+
+    Blank lines and lines whose first non-space character is ``#`` are
+    skipped so the file can carry human-readable comments without
+    confusing downstream processing.
+    """
+    urls: list[str] = []
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        urls.append(line)
+    return urls

--- a/backend/terramedic/organizations/management/commands/evaluate_urls_to_fixtures.py
+++ b/backend/terramedic/organizations/management/commands/evaluate_urls_to_fixtures.py
@@ -7,9 +7,8 @@ This is the local-only half of the re-evaluation workflow:
    ``zappa manage <env> "list_reevaluation_candidates" > urls.txt``
 2. Evaluate locally via the authenticated ``claude`` CLI (this
    command) — writes ``out.json``, no DB access needed.
-3. Ship the fixture back (``zappa update`` to package it, or copy
-   to S3 / the Zappa working tree) and load with
-   ``zappa manage <env> "loaddata out.json"``.
+3. Load the fixture into the remote environment with
+   ``python manage.py zappa_loaddata <stage> out.json``.
 
 Requires the shell to be logged into Claude Code (``claude auth``).
 """

--- a/backend/terramedic/organizations/management/commands/list_reevaluation_candidates.py
+++ b/backend/terramedic/organizations/management/commands/list_reevaluation_candidates.py
@@ -57,7 +57,17 @@ class Command(BaseCommand):
 
     def handle(self, *_args: Any, **options: Any) -> None:
         status_filter: str = options["status"]
-        qs = OrganizationEvaluation.objects.all().order_by("pk")
+        # Push filtering into the DB via JSONField path lookups so we
+        # never materialize full ``evaluation_data`` blobs client-side;
+        # pair with ``.iterator()`` to keep memory bounded on large
+        # result sets.
+        qs = OrganizationEvaluation.objects.exclude(
+            evaluation_data__prompt_version=PROMPT_VERSION,
+        ).exclude(
+            evaluation_data__org_metadata__website_url__isnull=True,
+        ).exclude(
+            evaluation_data__org_metadata__website_url="",
+        ).order_by("pk")
         if status_filter != "all":
             # Choice is validated to a ReviewStatus member; map
             # explicitly so the enum stays the source of truth.
@@ -68,11 +78,8 @@ class Command(BaseCommand):
             }
             qs = qs.filter(status=status_map[status_filter])
 
-        for ev in qs:
-            data = ev.evaluation_data or {}
-            if data.get("prompt_version") == PROMPT_VERSION:
-                continue
-            url = (data.get("org_metadata") or {}).get("website_url")
-            if not url:
-                continue
+        urls = qs.values_list(
+            "evaluation_data__org_metadata__website_url", flat=True,
+        ).iterator()
+        for url in urls:
             self.stdout.write(url)

--- a/backend/terramedic/organizations/management/commands/list_reevaluation_candidates.py
+++ b/backend/terramedic/organizations/management/commands/list_reevaluation_candidates.py
@@ -1,0 +1,78 @@
+"""Print website URLs of evaluations that predate the current
+``PROMPT_VERSION``.
+
+Lambda-safe (pure DB query, no external process). Intended to be run
+via ``zappa manage <env> "list_reevaluation_candidates"`` from a
+laptop that can't reach the private-subnet RDS directly — the stdout
+feeds into the local ``evaluate_urls_to_fixtures`` command, which
+shells out to the ``claude`` CLI.
+
+``--status`` selects which review states to include (default:
+``rejected``). Typical use:
+
+- ``rejected`` (default): revisit rejections that may have been
+  driven by the older prompt's weaknesses — most common flow after
+  a prompt bump, since reruns here can surface orgs that now qualify
+  without disturbing already-live approvals.
+- ``approved``: re-run live orgs if the prompt changes something
+  that should flow through (e.g. description wording).
+- ``pending``: supersede still-unreviewed evaluations with fresh
+  ones before a reviewer gets to them.
+- ``all``: every evaluation with a stale ``prompt_version``.
+"""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from curation.prompt import PROMPT_VERSION
+from terramedic.organizations.models import (
+    OrganizationEvaluation,
+    ReviewStatus,
+)
+
+_STATUS_CHOICES = ("pending", "approved", "rejected", "all")
+_DEFAULT_STATUS = "rejected"
+
+
+class Command(BaseCommand):
+    help = (
+        "Print website URLs of evaluations whose stored prompt_version"
+        f" lags the current {PROMPT_VERSION}. One URL per line,"
+        " pk-ascending for determinism. Filter by --status"
+        f" (default: {_DEFAULT_STATUS})."
+    )
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--status",
+            choices=_STATUS_CHOICES,
+            default=_DEFAULT_STATUS,
+            help="Review state to include. 'all' matches every status"
+                 f" (default: {_DEFAULT_STATUS}).",
+        )
+
+    def handle(self, *_args: Any, **options: Any) -> None:
+        status_filter: str = options["status"]
+        qs = OrganizationEvaluation.objects.all().order_by("pk")
+        if status_filter != "all":
+            # Choice is validated to a ReviewStatus member; map
+            # explicitly so the enum stays the source of truth.
+            status_map = {
+                "pending": ReviewStatus.PENDING,
+                "approved": ReviewStatus.APPROVED,
+                "rejected": ReviewStatus.REJECTED,
+            }
+            qs = qs.filter(status=status_map[status_filter])
+
+        for ev in qs:
+            data = ev.evaluation_data or {}
+            if data.get("prompt_version") == PROMPT_VERSION:
+                continue
+            url = (data.get("org_metadata") or {}).get("website_url")
+            if not url:
+                continue
+            self.stdout.write(url)

--- a/backend/terramedic/organizations/management/commands/zappa_loaddata.py
+++ b/backend/terramedic/organizations/management/commands/zappa_loaddata.py
@@ -1,0 +1,130 @@
+"""Load a Django fixture into a Zappa-deployed environment without
+a full ``zappa update`` redeploy.
+
+Bridges a local workflow step into the VPC: a curator generates
+fixtures on the ``claude``-authenticated laptop (via
+``evaluate_urls_to_fixtures``), then runs this command to push them
+straight into the target stage's DB. Internally, base64-encodes the
+fixture and hands it to ``zappa invoke --raw`` as a small Python
+snippet that pipes the decoded JSON to ``loaddata`` over stdin.
+
+Base64 keeps the snippet free of quotes/backslashes/shell
+metacharacters, so the encoded payload is safe to embed as a string
+literal in the snippet regardless of the fixture's contents.
+
+Example::
+
+    poetry run python manage.py zappa_loaddata dev reeval.json
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError
+
+# Lambda sync-invoke payload caps at 6 MB. We refuse anything over
+# 5 MB locally to leave ~1 MB of headroom for the surrounding Python
+# snippet, zappa's own envelope, and base64's ~33% overhead on the
+# wire. If a fixture exceeds this, upload to S3 and loaddata from
+# there — not worth inlining.
+_MAX_FIXTURE_BYTES = 5 * 1024 * 1024
+
+
+class Command(BaseCommand):
+    help = (
+        "Load a Django fixture JSON into a Zappa-deployed environment"
+        " without a full redeploy. Base64-encodes the fixture and"
+        " ships it to 'zappa invoke --raw' as a Python snippet that"
+        " pipes the content into loaddata over stdin."
+    )
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "stage",
+            help="Zappa stage name (e.g. dev, prod).",
+        )
+        parser.add_argument(
+            "fixture",
+            help="Path to the fixture JSON file to load.",
+        )
+
+    def handle(self, *_args: Any, **options: Any) -> None:
+        stage: str = options["stage"]
+        fixture_path = Path(str(options["fixture"]))
+
+        if not fixture_path.is_file():
+            raise CommandError(
+                f"Fixture not found: {fixture_path}",
+            )
+
+        payload = fixture_path.read_bytes()
+
+        if len(payload) > _MAX_FIXTURE_BYTES:
+            raise CommandError(
+                f"Fixture is {len(payload):,} bytes — too large for"
+                f" inline zappa invoke (limit"
+                f" {_MAX_FIXTURE_BYTES:,}). Upload to S3 and"
+                " loaddata from there.",
+            )
+
+        try:
+            json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise CommandError(
+                f"Fixture is not valid JSON: {exc}",
+            ) from exc
+
+        snippet = _build_invoke_snippet(payload)
+
+        self.stdout.write(
+            f"Loading {fixture_path} into {stage} via zappa invoke"
+            f" ({len(payload):,} bytes)...",
+        )
+        try:
+            result = subprocess.run(
+                ["zappa", "invoke", stage, snippet, "--raw"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise CommandError(
+                "Could not find the 'zappa' CLI on PATH — install"
+                " it locally (it's in the Poetry dev deps) and"
+                " retry.",
+            ) from exc
+
+        if result.returncode != 0:
+            raise CommandError(
+                f"zappa invoke failed (exit {result.returncode}):\n"
+                f"stdout: {result.stdout}\n"
+                f"stderr: {result.stderr}",
+            )
+
+        self.stdout.write(result.stdout)
+        self.stdout.write(self.style.SUCCESS("Fixture loaded."))
+
+
+def _build_invoke_snippet(fixture_bytes: bytes) -> str:
+    """Build the Python snippet handed to ``zappa invoke --raw``.
+
+    Base64-encoded content + single-quoted string literal keeps the
+    snippet safe from shell quoting issues and from any combination
+    of characters that might appear inside the fixture JSON.
+    """
+    encoded = base64.b64encode(fixture_bytes).decode("ascii")
+    return (
+        "import base64\n"
+        "from io import StringIO\n"
+        "from django.core.management import call_command\n"
+        f"data = base64.b64decode('{encoded}').decode('utf-8')\n"
+        "call_command("
+        "'loaddata', '--format=json', '-', stdin=StringIO(data)"
+        ")\n"
+    )

--- a/backend/terramedic/organizations/management/commands/zappa_loaddata.py
+++ b/backend/terramedic/organizations/management/commands/zappa_loaddata.py
@@ -28,12 +28,19 @@ from typing import Any
 
 from django.core.management.base import BaseCommand, CommandError
 
-# Lambda sync-invoke payload caps at 6 MB. We refuse anything over
-# 5 MB locally to leave ~1 MB of headroom for the surrounding Python
-# snippet, zappa's own envelope, and base64's ~33% overhead on the
-# wire. If a fixture exceeds this, upload to S3 and loaddata from
-# there — not worth inlining.
-_MAX_FIXTURE_BYTES = 5 * 1024 * 1024
+# Lambda sync-invoke payload caps at 6 MB. What actually goes over
+# the wire is the full invoke payload — the Python snippet we hand to
+# ``zappa invoke --raw``, with the fixture embedded as a base64 string
+# (~33% expansion) plus snippet scaffolding and zappa's envelope. A
+# ~5 MB raw fixture therefore lands at ~6.7 MB on the wire and fails
+# the Lambda limit even though the raw bytes would fit. We enforce
+# against the encoded payload size and leave ~256 KB for snippet and
+# envelope overhead. Fixtures past the limit should go via S3.
+_LAMBDA_INVOKE_LIMIT_BYTES = 6 * 1024 * 1024
+_SNIPPET_ENVELOPE_OVERHEAD_BYTES = 256 * 1024
+_MAX_ENCODED_PAYLOAD_BYTES = (
+    _LAMBDA_INVOKE_LIMIT_BYTES - _SNIPPET_ENVELOPE_OVERHEAD_BYTES
+)
 
 
 class Command(BaseCommand):
@@ -65,14 +72,6 @@ class Command(BaseCommand):
 
         payload = fixture_path.read_bytes()
 
-        if len(payload) > _MAX_FIXTURE_BYTES:
-            raise CommandError(
-                f"Fixture is {len(payload):,} bytes — too large for"
-                f" inline zappa invoke (limit"
-                f" {_MAX_FIXTURE_BYTES:,}). Upload to S3 and"
-                " loaddata from there.",
-            )
-
         try:
             json.loads(payload)
         except json.JSONDecodeError as exc:
@@ -81,6 +80,19 @@ class Command(BaseCommand):
             ) from exc
 
         snippet = _build_invoke_snippet(payload)
+
+        # Size-check the snippet that actually goes on the wire, not
+        # the raw fixture: base64 expands content ~33%, which can push
+        # an innocuous-looking fixture past the Lambda invoke limit.
+        encoded_size = len(snippet.encode("utf-8"))
+        if encoded_size > _MAX_ENCODED_PAYLOAD_BYTES:
+            raise CommandError(
+                f"Fixture is {len(payload):,} bytes raw and encodes"
+                f" to {encoded_size:,} bytes — too large for inline"
+                f" zappa invoke (limit"
+                f" {_MAX_ENCODED_PAYLOAD_BYTES:,}). Upload to S3 and"
+                " loaddata from there.",
+            )
 
         self.stdout.write(
             f"Loading {fixture_path} into {stage} via zappa invoke"

--- a/backend/terramedic/organizations/tests/test_evaluate_urls_to_fixtures.py
+++ b/backend/terramedic/organizations/tests/test_evaluate_urls_to_fixtures.py
@@ -278,6 +278,50 @@ class TestEvaluateUrlsToFixtures:
 
         mock_eval.assert_not_called()
 
+    def test_skips_non_http_lines_so_zappa_log_wrapping_survives(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``zappa manage ... "list_reevaluation_candidates"`` wraps
+        the command's stdout with Lambda log lines (START/END/REPORT,
+        ``Important! A new version of Zappa ...``, etc.). A curator
+        redirecting that straight to a file shouldn't have to strip
+        it by hand — only lines starting with http:// or https://
+        count as candidate URLs."""
+        urls_file = tmp_path / "urls.txt"
+        urls_file.write_text("\n".join([
+            "Important! A new version of Zappa is available!",
+            "START RequestId: abc Version: $LATEST",
+            "DEBUG handler Zappa Event: {...}",
+            "https://a.example",
+            "https://b.example",
+            "END RequestId: abc",
+            "REPORT Duration: 220ms",
+            "ftp://not-an-http-url.example",
+            "plain text that isn't a URL",
+        ]))
+        out_path = tmp_path / "out.json"
+
+        with patch(
+            f"{_EVAL_CMD_MODULE}.evaluate_org_via_claude_code",
+            side_effect=lambda url, **kw: _fake_eval(url, **kw),
+        ):
+            call_command(
+                "evaluate_urls_to_fixtures",
+                str(urls_file),
+                "--out",
+                str(out_path),
+            )
+
+        data = json.loads(out_path.read_text())
+        urls = [
+            row["fields"]["evaluation_data"]["org_metadata"][
+                "website_url"
+            ]
+            for row in data
+        ]
+        assert urls == ["https://a.example", "https://b.example"]
+
     def test_non_dry_run_requires_out_argument(
         self,
         tmp_path: Path,

--- a/backend/terramedic/organizations/tests/test_evaluate_urls_to_fixtures.py
+++ b/backend/terramedic/organizations/tests/test_evaluate_urls_to_fixtures.py
@@ -1,0 +1,296 @@
+"""Tests for the ``evaluate_urls_to_fixtures`` command.
+
+Local-only command that wraps ``evaluate_org_via_claude_code`` over a
+URL list and emits a single Django fixture JSON file. The output is
+designed to be loaded via ``loaddata`` through ``zappa manage`` —
+letting re-evaluations produce PENDING rows in the dev DB without
+sharing the DB with the laptop that ran the ``claude`` CLI.
+"""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+
+from terramedic.organizations.models import (
+    OrganizationEvaluation,
+    ReviewStatus,
+)
+
+_EVAL_CMD_MODULE = (
+    "terramedic.organizations.management.commands."
+    "evaluate_urls_to_fixtures"
+)
+
+
+def _fake_eval(url: str, **_: Any) -> dict[str, Any]:
+    """Minimal valid-enough evaluation payload for fixture tests."""
+    return {
+        "org_metadata": {
+            "name": f"Org for {url}",
+            "website_url": url,
+            "description": "Testing org description.",
+        },
+        "sdg_alignment": [
+            {"sdg": 15, "evidence": "Habitat work."},
+        ],
+        "evidence_of_work": [
+            {"activity": "Tree planting.", "type": "restoration"},
+        ],
+        "accessibility": {"categories": ["volunteer"]},
+        "evidence_score": {"score": 3, "rationale": "Moderate."},
+        "curator_notes": {
+            "recommendation": "include",
+            "confidence": 80,
+        },
+        "evaluated_at": "2026-04-20T21:00:00+00:00",
+        "evaluated_by": "claude-code:sonnet",
+        "prompt_version": "2026.04.10",
+    }
+
+
+@pytest.mark.django_db
+class TestEvaluateUrlsToFixtures:
+    def test_writes_one_fixture_row_per_input_url(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        urls_file = tmp_path / "urls.txt"
+        urls_file.write_text(
+            "https://a.example\nhttps://b.example\n",
+        )
+        out_path = tmp_path / "out.json"
+
+        with patch(
+            f"{_EVAL_CMD_MODULE}.evaluate_org_via_claude_code",
+            side_effect=lambda url, **kw: _fake_eval(url, **kw),
+        ):
+            call_command(
+                "evaluate_urls_to_fixtures",
+                str(urls_file),
+                "--out",
+                str(out_path),
+            )
+
+        data = json.loads(out_path.read_text())
+        assert len(data) == 2
+        for row in data:
+            assert row["model"] == "organizations.organizationevaluation"
+            assert row["fields"]["status"] == ReviewStatus.PENDING
+
+    def test_fixture_output_is_loaddata_compatible(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """End-to-end: the command's output round-trips through
+        Django's ``loaddata`` and produces a PENDING row whose
+        evaluation_data matches what claude-code returned."""
+        urls_file = tmp_path / "urls.txt"
+        urls_file.write_text("https://a.example\n")
+        out_path = tmp_path / "out.json"
+
+        with patch(
+            f"{_EVAL_CMD_MODULE}.evaluate_org_via_claude_code",
+            side_effect=lambda url, **kw: _fake_eval(url, **kw),
+        ):
+            call_command(
+                "evaluate_urls_to_fixtures",
+                str(urls_file),
+                "--out",
+                str(out_path),
+            )
+        call_command("loaddata", str(out_path))
+
+        assert OrganizationEvaluation.objects.count() == 1
+        ev = OrganizationEvaluation.objects.first()
+        assert ev is not None
+        assert ev.status == ReviewStatus.PENDING
+        assert ev.ai_recommendation == "include"
+        assert ev.ai_confidence == 80
+        assert ev.ai_model == "claude-code:sonnet"
+        assert (
+            ev.evaluation_data["org_metadata"]["website_url"]
+            == "https://a.example"
+        )
+
+    def test_skips_blank_lines_and_comments(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Real-world URL lists include blanks and `#` comments —
+        both should be ignored so a ``zappa manage list_... > f`` +
+        manual edits flow stays ergonomic."""
+        urls_file = tmp_path / "urls.txt"
+        urls_file.write_text(
+            "\n".join([
+                "https://a.example",
+                "",
+                "   ",
+                "# a comment",
+                "  # indented comment",
+                "https://b.example",
+                "",
+            ]),
+        )
+        out_path = tmp_path / "out.json"
+
+        with patch(
+            f"{_EVAL_CMD_MODULE}.evaluate_org_via_claude_code",
+            side_effect=lambda url, **kw: _fake_eval(url, **kw),
+        ):
+            call_command(
+                "evaluate_urls_to_fixtures",
+                str(urls_file),
+                "--out",
+                str(out_path),
+            )
+
+        data = json.loads(out_path.read_text())
+        urls = [
+            row["fields"]["evaluation_data"]["org_metadata"]["website_url"]
+            for row in data
+        ]
+        assert urls == ["https://a.example", "https://b.example"]
+
+    def test_eval_failure_is_logged_and_does_not_abort_batch(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A single URL's evaluation can fail (CLI timeout, schema
+        validation, etc.) without dropping the rest of the batch."""
+        urls_file = tmp_path / "urls.txt"
+        urls_file.write_text(
+            "https://broken.example\nhttps://ok.example\n",
+        )
+        out_path = tmp_path / "out.json"
+
+        def fake(url: str, **kw: Any) -> dict[str, Any]:
+            if "broken" in url:
+                raise RuntimeError("simulated CLI failure")
+            return _fake_eval(url, **kw)
+
+        with patch(
+            f"{_EVAL_CMD_MODULE}.evaluate_org_via_claude_code",
+            side_effect=fake,
+        ):
+            call_command(
+                "evaluate_urls_to_fixtures",
+                str(urls_file),
+                "--out",
+                str(out_path),
+            )
+
+        captured = capsys.readouterr()
+        assert "broken.example" in captured.err
+        assert "simulated CLI failure" in captured.err
+
+        data = json.loads(out_path.read_text())
+        urls = [
+            row["fields"]["evaluation_data"]["org_metadata"]["website_url"]
+            for row in data
+        ]
+        assert urls == ["https://ok.example"]
+
+    def test_empty_url_list_produces_empty_fixture(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """An empty candidates list — the common case right after a
+        prompt bump once everything is already caught up — writes an
+        empty fixture rather than erroring."""
+        urls_file = tmp_path / "urls.txt"
+        urls_file.write_text("\n# nothing here\n")
+        out_path = tmp_path / "out.json"
+
+        with patch(
+            f"{_EVAL_CMD_MODULE}.evaluate_org_via_claude_code",
+            side_effect=lambda url, **kw: _fake_eval(url, **kw),
+        ):
+            call_command(
+                "evaluate_urls_to_fixtures",
+                str(urls_file),
+                "--out",
+                str(out_path),
+            )
+
+        assert json.loads(out_path.read_text()) == []
+
+    def test_dry_run_lists_urls_without_calling_claude_or_writing(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``--dry-run`` lets a curator preview the URL list before
+        committing to a 10+ minute claude-code batch. It must skip
+        the CLI call entirely and must not write a fixture file."""
+        urls_file = tmp_path / "urls.txt"
+        urls_file.write_text(
+            "https://a.example\n# comment\nhttps://b.example\n",
+        )
+        out_path = tmp_path / "should-not-exist.json"
+
+        stdout = StringIO()
+        with patch(
+            f"{_EVAL_CMD_MODULE}.evaluate_org_via_claude_code",
+        ) as mock_eval:
+            call_command(
+                "evaluate_urls_to_fixtures",
+                str(urls_file),
+                "--out",
+                str(out_path),
+                "--dry-run",
+                stdout=stdout,
+            )
+
+        # The CLI wrapper was never called.
+        mock_eval.assert_not_called()
+        # No fixture file written.
+        assert not out_path.exists()
+        # Preview output mentions each URL.
+        output = stdout.getvalue()
+        assert "https://a.example" in output
+        assert "https://b.example" in output
+        assert "[dry-run]" in output
+
+    def test_dry_run_does_not_require_out_argument(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Previewing shouldn't force the caller to pick an output
+        path they don't plan to use."""
+        urls_file = tmp_path / "urls.txt"
+        urls_file.write_text("https://a.example\n")
+
+        with patch(
+            f"{_EVAL_CMD_MODULE}.evaluate_org_via_claude_code",
+        ) as mock_eval:
+            call_command(
+                "evaluate_urls_to_fixtures",
+                str(urls_file),
+                "--dry-run",
+            )
+
+        mock_eval.assert_not_called()
+
+    def test_non_dry_run_requires_out_argument(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A real run without ``--out`` is almost certainly a user
+        mistake — fail loudly rather than silently do nothing."""
+        from django.core.management.base import CommandError
+
+        urls_file = tmp_path / "urls.txt"
+        urls_file.write_text("https://a.example\n")
+
+        with pytest.raises(CommandError, match="--out"):
+            call_command(
+                "evaluate_urls_to_fixtures",
+                str(urls_file),
+            )

--- a/backend/terramedic/organizations/tests/test_list_reevaluation_candidates.py
+++ b/backend/terramedic/organizations/tests/test_list_reevaluation_candidates.py
@@ -1,0 +1,196 @@
+"""Tests for the ``list_reevaluation_candidates`` command.
+
+Runs against the dev DB via ``zappa manage`` to dump URLs of approved
+evaluations whose stored ``prompt_version`` lags the live one —
+input for the split re-evaluation workflow (evaluate locally via
+claude-code, loaddata fixtures back via zappa).
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from typing import Any
+
+import pytest
+from django.core.management import call_command
+
+from curation.prompt import PROMPT_VERSION
+from terramedic.organizations.models import (
+    OrganizationEvaluation,
+    ReviewStatus,
+)
+
+
+def _make_eval_data(
+    url: str = "https://example.org",
+    prompt_version: str = "2026.01.1",
+    name: str = "Example Org",
+) -> dict[str, Any]:
+    return {
+        "org_metadata": {"name": name, "website_url": url},
+        "prompt_version": prompt_version,
+    }
+
+
+@pytest.mark.django_db
+class TestListReevaluationCandidates:
+    def test_prints_urls_of_rejected_evals_with_stale_prompt_version(
+        self,
+    ) -> None:
+        OrganizationEvaluation.objects.create(
+            evaluation_data=_make_eval_data(
+                url="https://a.example", prompt_version="2026.01.1",
+            ),
+            status=ReviewStatus.REJECTED,
+        )
+        out = StringIO()
+        call_command("list_reevaluation_candidates", stdout=out)
+        assert out.getvalue().strip() == "https://a.example"
+
+    def test_excludes_evals_at_current_prompt_version(self) -> None:
+        """An eval already at the live PROMPT_VERSION has nothing to
+        re-run, regardless of its review state."""
+        OrganizationEvaluation.objects.create(
+            evaluation_data=_make_eval_data(
+                url="https://a.example", prompt_version=PROMPT_VERSION,
+            ),
+            status=ReviewStatus.REJECTED,
+        )
+        out = StringIO()
+        call_command("list_reevaluation_candidates", stdout=out)
+        assert out.getvalue().strip() == ""
+
+    def test_default_status_is_rejected_only(self) -> None:
+        """Default is 'rejected' because a prompt bump most commonly
+        surfaces orgs that previously didn't qualify — re-running the
+        rejection pool is the highest-yield first pass, and it
+        doesn't churn already-live approvals."""
+        for status, slug in (
+            (ReviewStatus.PENDING, "p"),
+            (ReviewStatus.APPROVED, "a"),
+        ):
+            OrganizationEvaluation.objects.create(
+                evaluation_data=_make_eval_data(
+                    url=f"https://{slug}.example",
+                    prompt_version="2026.01.1",
+                ),
+                status=status,
+            )
+        out = StringIO()
+        call_command("list_reevaluation_candidates", stdout=out)
+        assert out.getvalue().strip() == ""
+
+    @pytest.mark.parametrize(
+        ("status_arg", "matching_status", "slug"),
+        [
+            ("pending", ReviewStatus.PENDING, "p"),
+            ("rejected", ReviewStatus.REJECTED, "r"),
+        ],
+    )
+    def test_status_argument_selects_that_review_state(
+        self,
+        status_arg: str,
+        matching_status: str,
+        slug: str,
+    ) -> None:
+        """``--status pending`` / ``--status rejected`` let curators
+        target unreviewed or previously-rejected evals when
+        rebuilding after a prompt bump."""
+        OrganizationEvaluation.objects.create(
+            evaluation_data=_make_eval_data(
+                url=f"https://{slug}-match.example",
+                prompt_version="2026.01.1",
+            ),
+            status=matching_status,
+        )
+        # Different status that should be excluded by the filter.
+        OrganizationEvaluation.objects.create(
+            evaluation_data=_make_eval_data(
+                url="https://approved-excluded.example",
+                prompt_version="2026.01.1",
+            ),
+            status=ReviewStatus.APPROVED,
+        )
+        out = StringIO()
+        call_command(
+            "list_reevaluation_candidates",
+            "--status", status_arg,
+            stdout=out,
+        )
+        assert (
+            out.getvalue().strip() == f"https://{slug}-match.example"
+        )
+
+    def test_status_all_includes_every_review_state(self) -> None:
+        """``--status all`` is useful when a curator wants to see
+        everything that predates the current prompt, regardless of
+        where it is in the review pipeline."""
+        for status, slug in (
+            (ReviewStatus.PENDING, "p"),
+            (ReviewStatus.APPROVED, "a"),
+            (ReviewStatus.REJECTED, "r"),
+        ):
+            OrganizationEvaluation.objects.create(
+                evaluation_data=_make_eval_data(
+                    url=f"https://{slug}.example",
+                    prompt_version="2026.01.1",
+                ),
+                status=status,
+            )
+        out = StringIO()
+        call_command(
+            "list_reevaluation_candidates",
+            "--status", "all",
+            stdout=out,
+        )
+        assert sorted(out.getvalue().splitlines()) == [
+            "https://a.example",
+            "https://p.example",
+            "https://r.example",
+        ]
+
+    def test_invalid_status_argument_errors(self) -> None:
+        """argparse rejects an unknown ``--status`` value — caller
+        can't silently miss rows because they typo'd the flag."""
+        from django.core.management.base import CommandError
+
+        with pytest.raises((CommandError, SystemExit)):
+            call_command(
+                "list_reevaluation_candidates",
+                "--status", "nonsense",
+            )
+
+    def test_skips_approved_evals_missing_website_url(self) -> None:
+        """Silently skip rather than emit a blank line that would
+        confuse downstream piping to ``evaluate_urls_to_fixtures``."""
+        OrganizationEvaluation.objects.create(
+            evaluation_data={
+                "org_metadata": {"name": "No URL"},
+                "prompt_version": "2026.01.1",
+            },
+            status=ReviewStatus.APPROVED,
+        )
+        out = StringIO()
+        call_command("list_reevaluation_candidates", stdout=out)
+        assert out.getvalue().strip() == ""
+
+    def test_emits_one_url_per_line_in_pk_order(self) -> None:
+        """Order is stable and deterministic (pk asc) so re-running
+        the command produces the same URL list — useful when
+        `diff`-ing between runs or splitting batches."""
+        for url in (
+            "https://b.example",
+            "https://a.example",
+            "https://c.example",
+        ):
+            OrganizationEvaluation.objects.create(
+                evaluation_data=_make_eval_data(url=url),
+                status=ReviewStatus.REJECTED,
+            )
+        out = StringIO()
+        call_command("list_reevaluation_candidates", stdout=out)
+        assert out.getvalue().splitlines() == [
+            "https://b.example",
+            "https://a.example",
+            "https://c.example",
+        ]

--- a/backend/terramedic/organizations/tests/test_list_reevaluation_candidates.py
+++ b/backend/terramedic/organizations/tests/test_list_reevaluation_candidates.py
@@ -1,9 +1,10 @@
 """Tests for the ``list_reevaluation_candidates`` command.
 
-Runs against the dev DB via ``zappa manage`` to dump URLs of approved
-evaluations whose stored ``prompt_version`` lags the live one —
-input for the split re-evaluation workflow (evaluate locally via
-claude-code, loaddata fixtures back via zappa).
+Runs against the dev DB via ``zappa manage`` to dump URLs of
+evaluations whose stored ``prompt_version`` lags the live one
+(default pool: rejected; configurable via ``--status``) — input for
+the split re-evaluation workflow (evaluate locally via claude-code,
+loaddata fixtures back via zappa).
 """
 
 from __future__ import annotations

--- a/backend/terramedic/organizations/tests/test_list_reevaluation_candidates.py
+++ b/backend/terramedic/organizations/tests/test_list_reevaluation_candidates.py
@@ -171,7 +171,11 @@ class TestListReevaluationCandidates:
             status=ReviewStatus.APPROVED,
         )
         out = StringIO()
-        call_command("list_reevaluation_candidates", stdout=out)
+        call_command(
+            "list_reevaluation_candidates",
+            "--status", "approved",
+            stdout=out,
+        )
         assert out.getvalue().strip() == ""
 
     def test_emits_one_url_per_line_in_pk_order(self) -> None:

--- a/backend/terramedic/organizations/tests/test_zappa_loaddata.py
+++ b/backend/terramedic/organizations/tests/test_zappa_loaddata.py
@@ -95,7 +95,8 @@ class TestZappaLoaddata:
             call_command("zappa_loaddata", "dev", str(fixture))
 
         argv = mock_run.call_args.args[0]
-        # The snippet is the payload arg after --raw.
+        # argv is ["zappa", "invoke", stage, snippet, "--raw"] — the
+        # snippet sits before --raw, so match it by content.
         snippet = next(
             arg for arg in argv
             if isinstance(arg, str) and "base64" in arg

--- a/backend/terramedic/organizations/tests/test_zappa_loaddata.py
+++ b/backend/terramedic/organizations/tests/test_zappa_loaddata.py
@@ -1,0 +1,244 @@
+"""Tests for the ``zappa_loaddata`` command.
+
+Loads a Django fixture JSON into a Zappa-deployed environment without
+a full ``zappa update`` redeploy, by base64-encoding the fixture and
+handing it to ``zappa invoke --raw`` as a small Python snippet. Lets
+a curator re-evaluate orgs locally (via claude-code) and push results
+straight into the dev DB in one shot.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+_CMD_MODULE = (
+    "terramedic.organizations.management.commands.zappa_loaddata"
+)
+
+
+def _valid_fixture_bytes() -> bytes:
+    """A minimal two-row fixture that mirrors what
+    ``evaluate_urls_to_fixtures`` emits."""
+    return json.dumps([
+        {
+            "model": "organizations.organizationevaluation",
+            "fields": {
+                "evaluation_data": {"org_metadata": {"name": "A"}},
+                "status": "pending",
+                "created_at": "2026-04-20T21:00:00+00:00",
+            },
+        },
+        {
+            "model": "organizations.organizationevaluation",
+            "fields": {
+                "evaluation_data": {"org_metadata": {"name": "B"}},
+                "status": "pending",
+                "created_at": "2026-04-20T21:00:00+00:00",
+            },
+        },
+    ]).encode("utf-8")
+
+
+def _mock_run_ok() -> MagicMock:
+    """A ``subprocess.run`` mock that reports zappa success."""
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = "Installed 2 object(s) from 1 fixture(s)\n"
+    result.stderr = ""
+    return result
+
+
+class TestZappaLoaddata:
+    def test_invokes_zappa_invoke_with_raw_flag(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        fixture = tmp_path / "reeval.json"
+        fixture.write_bytes(_valid_fixture_bytes())
+
+        with patch(
+            f"{_CMD_MODULE}.subprocess.run",
+            return_value=_mock_run_ok(),
+        ) as mock_run:
+            call_command("zappa_loaddata", "dev", str(fixture))
+
+        mock_run.assert_called_once()
+        argv = mock_run.call_args.args[0]
+        # argv is a list passed to subprocess (no shell invocation).
+        assert argv[:3] == ["zappa", "invoke", "dev"]
+        assert "--raw" in argv
+
+    def test_embeds_fixture_as_base64_in_python_snippet(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Base64 keeps the snippet free of quotes/backslashes so
+        shell-escape bugs can't corrupt the fixture content."""
+        fixture_bytes = _valid_fixture_bytes()
+        fixture = tmp_path / "reeval.json"
+        fixture.write_bytes(fixture_bytes)
+        expected_b64 = base64.b64encode(fixture_bytes).decode("ascii")
+
+        with patch(
+            f"{_CMD_MODULE}.subprocess.run",
+            return_value=_mock_run_ok(),
+        ) as mock_run:
+            call_command("zappa_loaddata", "dev", str(fixture))
+
+        argv = mock_run.call_args.args[0]
+        # The snippet is the payload arg after --raw.
+        snippet = next(
+            arg for arg in argv
+            if isinstance(arg, str) and "base64" in arg
+        )
+        assert expected_b64 in snippet
+        assert "loaddata" in snippet
+
+    def test_passes_stage_argument_through_to_zappa(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        fixture = tmp_path / "reeval.json"
+        fixture.write_bytes(_valid_fixture_bytes())
+
+        with patch(
+            f"{_CMD_MODULE}.subprocess.run",
+            return_value=_mock_run_ok(),
+        ) as mock_run:
+            call_command("zappa_loaddata", "prod", str(fixture))
+
+        argv = mock_run.call_args.args[0]
+        assert "prod" in argv
+        assert "dev" not in argv
+
+    def test_missing_fixture_file_errors_clearly(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        missing = tmp_path / "nope.json"
+
+        with pytest.raises(CommandError, match="nope.json"):
+            call_command("zappa_loaddata", "dev", str(missing))
+
+    def test_invalid_json_errors_before_invoking_zappa(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Sanity-check parsing locally so a malformed fixture fails
+        in ~1 ms rather than after a Lambda round-trip."""
+        fixture = tmp_path / "bad.json"
+        fixture.write_text("{ not valid json")
+
+        with (
+            patch(f"{_CMD_MODULE}.subprocess.run") as mock_run,
+            pytest.raises(CommandError, match="JSON"),
+        ):
+            call_command("zappa_loaddata", "dev", str(fixture))
+
+        mock_run.assert_not_called()
+
+    def test_fixture_exceeding_size_limit_errors(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Lambda sync-invoke payload tops out at 6 MB; we refuse
+        fixtures over ~5 MB to leave headroom for the snippet."""
+        huge_rows = [
+            {
+                "model": "organizations.organizationevaluation",
+                "fields": {
+                    "evaluation_data": {"blob": "x" * 10_000},
+                    "status": "pending",
+                    "created_at": "2026-04-20T21:00:00+00:00",
+                },
+            }
+            for _ in range(600)
+        ]
+        fixture = tmp_path / "big.json"
+        fixture.write_bytes(json.dumps(huge_rows).encode("utf-8"))
+
+        with (
+            patch(f"{_CMD_MODULE}.subprocess.run") as mock_run,
+            pytest.raises(CommandError, match="too large"),
+        ):
+            call_command("zappa_loaddata", "dev", str(fixture))
+
+        mock_run.assert_not_called()
+
+    def test_zappa_nonzero_exit_becomes_command_error(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Surface zappa's stderr in the exception so a failed run
+        gives the curator enough info to diagnose without hunting
+        through subprocess output."""
+        fixture = tmp_path / "reeval.json"
+        fixture.write_bytes(_valid_fixture_bytes())
+
+        failed = MagicMock(returncode=1, stdout="", stderr="boom")
+        with (
+            patch(
+                f"{_CMD_MODULE}.subprocess.run", return_value=failed,
+            ),
+            pytest.raises(CommandError, match="boom"),
+        ):
+            call_command("zappa_loaddata", "dev", str(fixture))
+
+    def test_missing_zappa_binary_gives_actionable_error(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``FileNotFoundError`` from subprocess is cryptic; translate
+        it to a message that names the missing binary."""
+        fixture = tmp_path / "reeval.json"
+        fixture.write_bytes(_valid_fixture_bytes())
+
+        with (
+            patch(
+                f"{_CMD_MODULE}.subprocess.run",
+                side_effect=FileNotFoundError(2, "not found", "zappa"),
+            ),
+            pytest.raises(CommandError, match="zappa"),
+        ):
+            call_command("zappa_loaddata", "dev", str(fixture))
+
+    def test_subprocess_called_without_shell_interpolation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Double-check that we never hand a command string to a
+        shell — argv must be a list. Prevents shell-injection if a
+        future fixture path or stage ends up reflecting user input."""
+        fixture = tmp_path / "reeval.json"
+        fixture.write_bytes(_valid_fixture_bytes())
+
+        with patch(
+            f"{_CMD_MODULE}.subprocess.run",
+            return_value=_mock_run_ok(),
+        ) as mock_run:
+            call_command("zappa_loaddata", "dev", str(fixture))
+
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("shell", False) is False
+        assert isinstance(mock_run.call_args.args[0], list)
+
+
+@pytest.mark.parametrize("_fixture", [_valid_fixture_bytes()])
+def test_subprocess_module_is_the_real_one(_fixture: Any) -> None:
+    """Guard rail: the tests patch ``subprocess.run`` on the command
+    module's namespace. If the import path changes, the patch falls
+    through to the real subprocess and tests would hit the zappa
+    binary for real. This test fails loudly in that case."""
+    from terramedic.organizations.management.commands import (
+        zappa_loaddata,
+    )
+    assert zappa_loaddata.subprocess is subprocess

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -128,6 +128,9 @@ EventBridge (5 min)
   `EVALUATION_RESULTS_QUEUE_URL` are set as GitHub
   environment variables (dev, prod) so Zappa injects
   them at deploy time.
+- For the admin procedure that re-runs existing
+  evaluations after a `PROMPT_VERSION` bump, see
+  [RUNBOOKS.md](RUNBOOKS.md).
 
 ## Infrastructure
 

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -88,9 +88,11 @@ and the Lambda environment (inside the VPC, no `claude` binary).
 
    Base64-encodes the fixture and hands it to `zappa invoke --raw`,
    which decodes it and pipes it into Django's `loaddata` over
-   stdin. The 6 MB Lambda sync-invoke payload limit applies — the
-   command refuses fixtures over ~5 MB and suggests uploading to
-   S3 instead.
+   stdin. The 6 MB Lambda sync-invoke payload limit applies to the
+   full snippet going on the wire — since base64 expands content
+   ~33%, the command refuses fixtures whose encoded payload would
+   exceed the limit (~4 MB raw in practice) and suggests uploading
+   to S3 instead.
 
 ### Verification
 

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -1,0 +1,117 @@
+# Runbooks
+
+Admin procedures for running Terramedic in production. Each section
+is self-contained: pre-requisites, steps, verification. For the
+system architecture behind these procedures, see
+[ARCHITECTURE.md](ARCHITECTURE.md).
+
+## Re-evaluating organizations after a prompt-version bump
+
+When `curation.prompt.PROMPT_VERSION` changes, existing
+`OrganizationEvaluation` rows stay frozen at the old version — their
+stored `evaluation_data.prompt_version` does not update
+automatically. Re-running them against the new prompt is a
+three-step procedure that splits work between your local machine
+(authenticated to the `claude` CLI, no VPC access to the dev RDS)
+and the Lambda environment (inside the VPC, no `claude` binary).
+
+### When to run
+
+- After merging a PR that bumps `PROMPT_VERSION`, when you want the
+  existing evaluation pool to reflect the new criteria.
+- Most common scenario: the new prompt tightens a criterion and
+  some previously-rejected orgs should get another look. The
+  default `--status rejected` below targets exactly that pool.
+
+### Pre-requisites
+
+- Logged in to the `claude` CLI on your local machine (`claude
+  auth`). The re-evaluation shells out to it.
+- `zappa` CLI installed locally (it's in the Poetry dev deps) and
+  configured for the target stage.
+- Clean working tree on a `dev`-based branch you're happy to have
+  loaded, in case you need to iterate on fixture generation.
+
+### Steps
+
+1. **List the candidate URLs from the dev DB.**
+
+   ```bash
+   zappa manage dev "list_reevaluation_candidates" > urls.txt
+   ```
+
+   Prints URLs of evaluations whose stored `prompt_version` lags the
+   current one. `--status` selects which review states to include:
+
+   - `rejected` (default) — revisit rejections that may have been
+     driven by the old prompt's weaknesses.
+   - `approved` — re-run live orgs if the prompt change should
+     propagate to their descriptions or categories.
+   - `pending` — supersede still-unreviewed evaluations.
+   - `all` — every evaluation behind the current version.
+
+   To pass `--status`, quote the full command:
+
+   ```bash
+   zappa manage dev "list_reevaluation_candidates --status all" \
+     > urls.txt
+   ```
+
+2. **Evaluate locally via claude-code and write a fixture.**
+
+   ```bash
+   poetry run python manage.py evaluate_urls_to_fixtures \
+     urls.txt --out reeval.json
+   ```
+
+   The command shells out to `evaluate_org_via_claude_code` for
+   each URL, tolerates per-URL failures (logs and continues), and
+   writes a single Django fixture file. Blank lines and `#`
+   comments in `urls.txt` are ignored.
+
+   Preview first if the URL list is long:
+
+   ```bash
+   poetry run python manage.py evaluate_urls_to_fixtures \
+     urls.txt --dry-run
+   ```
+
+3. **Push the fixture into the target stage without redeploying.**
+
+   ```bash
+   poetry run python manage.py zappa_loaddata dev reeval.json
+   ```
+
+   Base64-encodes the fixture and hands it to `zappa invoke --raw`,
+   which decodes it and pipes it into Django's `loaddata` over
+   stdin. The 6 MB Lambda sync-invoke payload limit applies — the
+   command refuses fixtures over ~5 MB and suggests uploading to
+   S3 instead.
+
+### Verification
+
+- The new rows appear in the admin evaluation queue at
+  `/admin/organizations/organizationevaluation/?status__exact=pending`.
+- Spot-check one: open the detail page, confirm `prompt_version`
+  in the raw data matches the current `PROMPT_VERSION`, and that
+  the categories / description reflect the updated prompt.
+- Approving a new row creates a fresh `Organization` via the
+  `create_org_on_approval` signal. If the URL already has a
+  live `Organization` from the prior evaluation, both will exist
+  — deactivate the old one manually (`is_active = False`) once
+  you're satisfied with the new evaluation.
+
+### Troubleshooting
+
+- **`list_reevaluation_candidates` prints nothing.** Every eval
+  in the selected status pool is already at the current
+  `PROMPT_VERSION`. Try `--status all` or confirm the prompt
+  version actually changed.
+- **`evaluate_urls_to_fixtures` reports FAILED for some URLs.**
+  Usually either the `claude` CLI session expired (`claude auth`
+  to refresh) or the org's website is unreachable. Re-run the
+  command against a filtered URL list — it's idempotent at the
+  fixture-write level (each run writes its own file).
+- **`zappa_loaddata` fails with "too large".** Split the fixture
+  into chunks by URL and run the command per chunk, or upload
+  the fixture to S3 and load from there with a small wrapper.

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -26,18 +26,19 @@ and the Lambda environment (inside the VPC, no `claude` binary).
 ### Pre-requisites
 
 - Logged in to the `claude` CLI on your local machine (`claude
-  auth`). The re-evaluation shells out to it.
-- `zappa` CLI installed locally (it's in the Poetry dev deps) and
-  configured for the target stage.
-- Clean working tree on a `dev`-based branch you're happy to have
-  loaded, in case you need to iterate on fixture generation.
+  auth`). The fixture-generation step shells out to it.
+- AWS credentials for the target stage available via `aws-vault`
+  (or whatever wrapper your workstation uses). The commands that
+  call `zappa` need creds for the stage's account.
 
 ### Steps
 
 1. **List the candidate URLs from the dev DB.**
 
    ```bash
-   zappa manage dev "list_reevaluation_candidates" > urls.txt
+   aws-vault exec terramedic-dev -- \
+     poetry run zappa manage dev \
+     "list_reevaluation_candidates" > urls.txt
    ```
 
    Prints URLs of evaluations whose stored `prompt_version` lags the
@@ -50,14 +51,16 @@ and the Lambda environment (inside the VPC, no `claude` binary).
    - `pending` — supersede still-unreviewed evaluations.
    - `all` — every evaluation behind the current version.
 
-   To pass `--status`, quote the full command:
+   Pass `--status` inside the quoted command:
 
    ```bash
-   zappa manage dev "list_reevaluation_candidates --status all" \
-     > urls.txt
+   aws-vault exec terramedic-dev -- \
+     poetry run zappa manage dev \
+     "list_reevaluation_candidates --status all" > urls.txt
    ```
 
-2. **Evaluate locally via claude-code and write a fixture.**
+2. **Evaluate locally via claude-code and write a fixture.** No
+   AWS creds needed — this step runs entirely on your machine:
 
    ```bash
    poetry run python manage.py evaluate_urls_to_fixtures \
@@ -79,7 +82,8 @@ and the Lambda environment (inside the VPC, no `claude` binary).
 3. **Push the fixture into the target stage without redeploying.**
 
    ```bash
-   poetry run python manage.py zappa_loaddata dev reeval.json
+   aws-vault exec terramedic-dev -- \
+     poetry run python manage.py zappa_loaddata dev reeval.json
    ```
 
    Base64-encodes the fixture and hands it to `zappa invoke --raw`,


### PR DESCRIPTION
## Summary

Adds three management commands and a runbook that together let a curator re-evaluate existing `OrganizationEvaluation` rows after a `PROMPT_VERSION` bump, without:

- direct laptop access to the private-subnet dev RDS, and
- without a full `zappa update` redeploy cycle.

Work is split between the local machine (where the `claude` CLI is authenticated) and the Lambda environment (which has VPC access to the DB).

### New commands

- **`list_reevaluation_candidates`** (Lambda-safe, pure DB query). Prints URLs of evaluations whose stored `prompt_version` lags the current one. `--status {pending,approved,rejected,all}` selects the pool; default is `rejected` (prompt bumps most commonly surface previously-rejected orgs that now qualify).
- **`evaluate_urls_to_fixtures`** (local-only). Takes a URLs file, shells out to `evaluate_org_via_claude_code` per URL, writes a single Django fixture JSON. Tolerates per-URL failures. `--dry-run` previews the URL list before committing to a 10+ minute claude-code batch. Output includes `created_at` since `loaddata` bypasses `auto_now_add`.
- **`zappa_loaddata`** (local-only). Base64-encodes a fixture and hands it to `zappa invoke --raw`, which decodes it and pipes into Django's `loaddata` over stdin. Refuses fixtures over ~5 MB (Lambda's 6 MB sync-invoke payload limit with headroom). No redeploy needed.

### Docs

- `docs/RUNBOOKS.md` — new admin-runbook file with a complete "Re-evaluating organizations after a prompt-version bump" section: pre-requisites, steps, verification, troubleshooting.
- `docs/ARCHITECTURE.md` — one-line pointer to the runbook from the evaluation-pipeline section.

## Test plan

- [x] `SECRET_KEY=test poetry run pytest` — 605 passed (27 new tests across the three commands + subprocess mocking for `zappa_loaddata`)
- [x] `poetry run ruff check .` — clean
- [ ] Run `zappa manage dev "list_reevaluation_candidates"` against the current dev DB, verify it prints URLs for the rejected pool
- [ ] Generate a one-URL fixture locally, verify `evaluate_urls_to_fixtures --dry-run` lists the URL without hitting the CLI
- [ ] Run `zappa_loaddata dev <small-fixture>` end-to-end, verify a PENDING row appears in the dev admin
- [ ] Walk the runbook in `docs/RUNBOOKS.md` with the 15 orgs currently in dev

## Follow-ups

- If the batch ever exceeds the ~5 MB inline limit, add S3 support to `zappa_loaddata` (upload + loaddata-from-S3 wrapper). Noted in the runbook's troubleshooting section.
- Auto-deactivate prior `Organization` rows when a re-evaluation for the same URL is approved — currently the curator has to do this manually.