### PR TITLE
ci(secret-scan): run open-source gitleaks CLI instead of licensed action

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -10,13 +10,25 @@ on:
       - main
       - dev
 jobs:
+  # Runs the open-source gitleaks CLI directly instead of gitleaks/gitleaks-action.
+  # The action requires a paid GITLEAKS_LICENSE for organization repos, and that
+  # secret is not exposed to Dependabot-triggered workflow runs, so every
+  # Dependabot PR failed this required check. The CLI needs no license and scans
+  # identically for every event.
   gitleaks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+      - name: Install gitleaks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_VERSION: 8.30.0
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --location \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+      - name: Scan git history for secrets
+        run: gitleaks git . --config .gitleaks.toml --no-banner --redact --verbose


### PR DESCRIPTION
## Problem

The required `gitleaks` status check fails on **every** Dependabot PR, blocking all 16 of them from merging.

Root cause: `gitleaks/gitleaks-action` requires a paid `GITLEAKS_LICENSE` for organization repos. That secret is an Actions secret, which is **not exposed to Dependabot-triggered workflow runs** (the run log shows `Secret source: Dependabot` and an empty `GITLEAKS_LICENSE`). So the action exits with *"missing gitleaks license"*. Non-Dependabot pushes/PRs pass because they can see the secret — which is why `main` has been green.

## Fix

Run the **open-source gitleaks CLI** (v8.30.0, pinned) directly instead of the licensed action. No license required; scans git history identically and honors the existing `.gitleaks.toml` allowlist. The job id stays `gitleaks` so it still satisfies the required status-check context.

## Validation

Ran locally against full history (2338 commits, ~1.9 GB): **no leaks found**, exit 0.

This removes the paid-license coupling entirely and unblocks the Dependabot queue once each PR is rebased onto this change.