### PR TITLE
chore(ci): group the eslint core in dependabot so it bumps in lockstep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,22 +23,13 @@ updates:
       include: ["*"]
     # Group development dependencies together
     groups:
-      # Keep the vitest family in lockstep across ALL update types, including
-      # major. vitest, @vitest/browser and @vitest/coverage-v8 must share the
-      # exact same version (the latter two are exact-pinned to vitest in
-      # package.json), so a single-package bump breaks the test runner. Listing
-      # it first and omitting update-types ensures every vitest bump lands as one
-      # coordinated PR instead of separate, coupling-breaking ones.
+      # @vitest/* are exact-pinned to vitest, so they must bump together (all
+      # update types).
       vitest:
         patterns:
           - "vitest"
           - "@vitest/*"
-      # Keep the eslint core in lockstep across ALL update types. eslint and
-      # @eslint/js move together on majors (e.g. 9 -> 10); because the
-      # dev-dependencies group only covered minor/patch — and its "eslint*"
-      # pattern never matched the scoped "@eslint/js" — these arrived as separate
-      # PRs that had to be merged as a coordinated pair (#173 + #174). Grouping
-      # eslint with @eslint/* lands them as one PR.
+      # eslint and @eslint/* are version-coupled on majors, so they bump together.
       eslint:
         patterns:
           - "eslint"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,12 +33,23 @@ updates:
         patterns:
           - "vitest"
           - "@vitest/*"
+      # Keep the eslint core in lockstep across ALL update types. eslint and
+      # @eslint/js move together on majors (e.g. 9 -> 10); because the
+      # dev-dependencies group only covered minor/patch — and its "eslint*"
+      # pattern never matched the scoped "@eslint/js" — these arrived as separate
+      # PRs that had to be merged as a coordinated pair (#173 + #174). Grouping
+      # eslint with @eslint/* lands them as one PR.
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
       dev-dependencies:
         patterns:
           - "@storybook/*"
           - "@testing-library/*"
           - "@playwright/*"
-          - "eslint*"
+          - "eslint-config-*"
+          - "eslint-plugin-*"
           - "prettier*"
           - "playwright"
         update-types:


### PR DESCRIPTION
Follow-up to #248 (which grouped the vitest family). Same idea, for the eslint core.

## Why
`eslint` and `@eslint/js` move together on majors (e.g. 9 → 10). The `dev-dependencies` group only covered `minor`/`patch`, and its `eslint*` pattern never even matched the scoped `@eslint/js` — so they arrived as separate PRs that had to be merged as a coordinated pair (#173 + #174) during the recent Dependabot cleanup.

## Change
Add a dedicated **`eslint` group** (`eslint`, `@eslint/*`) with **no `update-types` restriction** (covers major/minor/patch), and narrow the `dev-dependencies` eslint patterns from `eslint*` to `eslint-config-*` / `eslint-plugin-*` so the core no longer double-matches:

```yaml
groups:
  vitest:            # already on main (from #248)
    patterns: ["vitest", "@vitest/*"]
  eslint:            # new
    patterns: ["eslint", "@eslint/*"]
  dev-dependencies:
    patterns:
      - "@storybook/*"
      - "@testing-library/*"
      - "@playwright/*"
      - "eslint-config-*"   # was: eslint*
      - "eslint-plugin-*"   # was: eslint*
      - "prettier*"
      - "playwright"
    update-types: [minor, patch]
```

## Effect
- `eslint` + `@eslint/js` now land as **one coordinated PR**, including majors.
- Major group bumps still won't auto-merge (the auto-merge workflow reports `semver-major` for a group containing a major), so they keep getting human review.
- `eslint-config-prettier` and `eslint-plugin-svelte` stay in `dev-dependencies` (minor/patch) as before.

(This is the eslint half of #248 — it got squash-merged with only the vitest commit before I pushed this part, so it's a standalone PR off current `main`.)