### PR TITLE
chore(ci): update CodeQL actions together

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,7 +39,7 @@ jobs:
           node-version: 20.x
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -66,6 +66,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

- Update both `github/codeql-action/init` and `github/codeql-action/analyze` from the v4.36.2 pinned SHA to the v4.37.3 pinned SHA.
- Keep CodeQL initialization and analysis on the same release so their configuration formats remain compatible.
- Supersede the split updates in #293 and #298 with one atomic workflow change.

## Why

Each split Dependabot PR updates only one CodeQL step. That mixes v4.36.2 and v4.37.3 in a single job, causing the JavaScript/TypeScript analysis check to fail with a configuration-version mismatch. Updating both steps together removes that mismatch.

## Validation

- `git diff --check`
- Repository-equivalent `yamllint` configuration over `.github/workflows/` (exit 0; existing warning-level notices only)
- GitHub Actions: 14 successful, 0 failing, 0 pending; CodeQL analysis passed